### PR TITLE
Adds a simple CLI to client_wrapper

### DIFF
--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -26,17 +26,21 @@ import results
 
 class NdtHtml5SeleniumDriver(object):
 
-    def perform_test(self, url, browser, timeout):
-        """Performs an NDT test with the HTML5 client in the specified browser.
-
-        Performs a full NDT test (both s2c and c2s) using the specified
-        browser.
+    def __init__(self, browser, url, timeout):
+        """Creates a NDT HTML5 client driver for the given URL and browser.
 
         Args:
             url: The URL of an NDT server to test against.
             browser: Can be one of 'firefox', 'chrome', 'edge', or 'safari'.
-            timeout: The number of seconds that the driver will wait for
-                each element to become visible before timing out.
+            timeout: The number of seconds that the driver will wait for each
+                element to become visible before timing out.
+        """
+        self._browser = browser
+        self._url = url
+        self._timeout = timeout
+
+    def perform_test(self):
+        """Performs a full NDT test (both s2c and c2s) with the HTML5 client.
 
         Returns:
             A populated NdtResult object.
@@ -47,14 +51,15 @@ class NdtHtml5SeleniumDriver(object):
                                    s2c_start_time=None,
                                    errors=[])
 
-        with contextlib.closing(_create_browser(browser)) as driver:
+        with contextlib.closing(_create_browser(self._browser)) as driver:
 
-            if not _load_url(driver, url, result):
+            if not _load_url(driver, self._url, result):
                 return result
 
             _click_start_button(driver, result)
 
-            if not _record_test_in_progress_values(result, driver, timeout):
+            if not _record_test_in_progress_values(result, driver,
+                                                   self._timeout):
                 return result
 
             if not _populate_metric_values(result, driver):

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -44,10 +44,10 @@ class NdtHtml5SeleniumDriverGeneralTest(unittest.TestCase):
         self.mock_browser.get.side_effect = exceptions.WebDriverException(
             u'Failed to load test UI.')
 
-        selenium_driver = html5_driver.NdtHtml5SeleniumDriver()
-        test_results = selenium_driver.perform_test(url='invalid_url',
-                                                    browser='firefox',
-                                                    timeout=1)
+        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='invalid_url',
+            timeout=1).perform_test()
 
         # We have one error
         self.assertEqual(len(test_results.errors), 1)
@@ -62,11 +62,10 @@ class NdtHtml5SeleniumDriverGeneralTest(unittest.TestCase):
                                'WebDriverWait',
                                side_effect=exceptions.TimeoutException,
                                autospec=True):
-            selenium_driver = html5_driver.NdtHtml5SeleniumDriver()
-            test_results = selenium_driver.perform_test(
-                url='http://ndt.mock-server.com:7123/',
+            test_results = html5_driver.NdtHtml5SeleniumDriver(
                 browser='firefox',
-                timeout=1)
+                url='http://ndt.mock-server.com:7123/',
+                timeout=1).perform_test()
 
         # We have one error
         self.assertEqual(len(test_results.errors), 1)
@@ -76,26 +75,30 @@ class NdtHtml5SeleniumDriverGeneralTest(unittest.TestCase):
                          'Test did not complete within timeout period.')
 
     def test_unimplemented_browsers_raise_error(self):
-        selenium_driver = html5_driver.NdtHtml5SeleniumDriver()
+
         with self.assertRaises(NotImplementedError):
-            selenium_driver.perform_test(url='http://ndt.mock-server.com:7123',
-                                         browser='chrome',
-                                         timeout=1)
+            html5_driver.NdtHtml5SeleniumDriver(
+                browser='chrome',
+                url='http://ndt.mock-server.com:7123',
+                timeout=1).perform_test()
         with self.assertRaises(NotImplementedError):
-            selenium_driver.perform_test(url='http://ndt.mock-server.com:7123',
-                                         browser='edge',
-                                         timeout=1)
+            html5_driver.NdtHtml5SeleniumDriver(
+                browser='edge',
+                url='http://ndt.mock-server.com:7123',
+                timeout=1).perform_test()
         with self.assertRaises(NotImplementedError):
-            selenium_driver.perform_test(url='http://ndt.mock-server.com:7123',
-                                         browser='safari',
-                                         timeout=1)
+            html5_driver.NdtHtml5SeleniumDriver(
+                browser='safari',
+                url='http://ndt.mock-server.com:7123',
+                timeout=1).perform_test()
 
     def test_unrecognized_browser_raises_error(self):
-        selenium_driver = html5_driver.NdtHtml5SeleniumDriver()
+        selenium_driver = html5_driver.NdtHtml5SeleniumDriver(
+            browser='not_a_browser',
+            url='http://ndt.mock-server.com:7123',
+            timeout=1)
         with self.assertRaises(ValueError):
-            selenium_driver.perform_test(url='http://ndt.mock-server.com:7123',
-                                         browser='not_a_browser',
-                                         timeout=1)
+            selenium_driver.perform_test()
 
     @freezegun.freeze_time('2016-01-01', tz_offset=0)
     def test_ndt_test_results_records_todays_times(self):
@@ -103,11 +106,10 @@ class NdtHtml5SeleniumDriverGeneralTest(unittest.TestCase):
         self.assertEqual(datetime.datetime.now(), datetime.datetime(2016, 1, 1))
 
         with mock.patch.object(html5_driver.ui, 'WebDriverWait', autospec=True):
-            selenium_driver = html5_driver.NdtHtml5SeleniumDriver()
-            test_results = selenium_driver.perform_test(
-                url='http://ndt.mock-server.com:7123/',
+            test_results = html5_driver.NdtHtml5SeleniumDriver(
                 browser='firefox',
-                timeout=1)
+                url='http://ndt.mock-server.com:7123/',
+                timeout=1).perform_test()
 
         # Then the readings for our test start and end times occur within
         # today's date
@@ -134,12 +136,10 @@ class NdtHtml5SeleniumDriverGeneralTest(unittest.TestCase):
                                autospec=True) as mocked_datetime:
 
             mocked_datetime.now.side_effect = dates
-            selenium_driver = html5_driver.NdtHtml5SeleniumDriver()
-
-            test_results = selenium_driver.perform_test(
-                url='http://ndt.mock-server.com:7123/',
+            test_results = html5_driver.NdtHtml5SeleniumDriver(
                 browser='firefox',
-                timeout=1)
+                url='http://ndt.mock-server.com:7123/',
+                timeout=1).perform_test()
 
         # And the sequence of returned values follows the expected timeline
         # that the readings are taken in.
@@ -224,11 +224,10 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
                                autospec=True,
                                return_value=NewDriver()):
 
-            selenium_driver = html5_driver.NdtHtml5SeleniumDriver()
-            test_results = selenium_driver.perform_test(
-                url='http://ndt.mock-server.com:7123/',
+            test_results = html5_driver.NdtHtml5SeleniumDriver(
                 browser='firefox',
-                timeout=1000)
+                url='http://ndt.mock-server.com:7123/',
+                timeout=1000).perform_test()
 
         # And the appropriate error objects are contained in
         # the list
@@ -272,11 +271,10 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
                                autospec=True,
                                return_value=NewDriver()):
 
-            selenium_driver = html5_driver.NdtHtml5SeleniumDriver()
-            test_results = selenium_driver.perform_test(
-                url='http://ndt.mock-server.com:7123/',
+            test_results = html5_driver.NdtHtml5SeleniumDriver(
                 browser='firefox',
-                timeout=1000)
+                url='http://ndt.mock-server.com:7123/',
+                timeout=1000).perform_test()
 
         self.assertEqual(test_results.latency, '72')
         # And an error object is not contained in the list


### PR DESCRIPTION
This adds a simple command line interface to client_wrapper

This also makes a slight change to NdtHtml5SeleniumDriver's semantics in
that now the perform_test() call has no arguments. This allows us to use
a consistent perform_test() call across different drivers (including
browserless clients).

Note that, at this point, all CLI output (everything in the main() function) is
just placeholder and likely will change in the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/4)
<!-- Reviewable:end -->
