### PR TITLE
Html5 driver implementation of `NdtSingleTestResult`

### DIFF
--- a/client_wrapper/client_wrapper.py
+++ b/client_wrapper/client_wrapper.py
@@ -30,6 +30,8 @@ def main(args):
     for i in range(args.iterations):
         print 'starting iteration %d...' % (i + 1)
         result = driver.perform_test()
+        import ipdb
+        ipdb.set_trace()
         print '\tc2s_throughput: %s Mbps' % result.c2s_result.throughput
         print '\ts2c_throughput: %s Mbps' % result.s2c_result.throughput
         if result.errors:

--- a/client_wrapper/client_wrapper.py
+++ b/client_wrapper/client_wrapper.py
@@ -30,8 +30,8 @@ def main(args):
     for i in range(args.iterations):
         print 'starting iteration %d...' % (i + 1)
         result = driver.perform_test()
-        print '\tc2s_throughput: %s Mbps' % result.c2s_throughput
-        print '\ts2c_throughput: %s Mbps' % result.s2c_throughput
+        print '\tc2s_throughput: %s Mbps' % result.c2s_result.throughput
+        print '\ts2c_throughput: %s Mbps' % result.s2c_result.throughput
         if result.errors:
             print '\terrors:'
             for error in result.errors:

--- a/client_wrapper/client_wrapper.py
+++ b/client_wrapper/client_wrapper.py
@@ -30,8 +30,7 @@ def main(args):
     for i in range(args.iterations):
         print 'starting iteration %d...' % (i + 1)
         result = driver.perform_test()
-        import ipdb
-        ipdb.set_trace()
+
         print '\tc2s_throughput: %s Mbps' % result.c2s_result.throughput
         print '\ts2c_throughput: %s Mbps' % result.s2c_result.throughput
         if result.errors:

--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -144,21 +144,25 @@ def _record_test_in_progress_values(result, driver, timeout):
         # wait until 'Now Testing your upload speed' is displayed
         upload_speed_text = driver.find_elements_by_xpath(
             "//*[contains(text(), 'your upload speed')]")[0]
-        result.c2s_start_time = _record_time_when_element_displayed(
+        result.c2s_result = results.NdtSingleTestResult()
+        result.c2s_result.start_time = _record_time_when_element_displayed(
             upload_speed_text,
             driver,
             timeout=timeout)
+        result.c2s_result.end_time = datetime.datetime.now(pytz.utc)
 
         # wait until 'Now Testing your download speed' is displayed
         download_speed_text = driver.find_elements_by_xpath(
             "//*[contains(text(), 'your download speed')]")[0]
-        result.s2c_start_time = _record_time_when_element_displayed(
+        result.s2c_result = results.NdtSingleTestResult()
+        result.s2c_result.start_time = _record_time_when_element_displayed(
             download_speed_text,
             driver,
             timeout=timeout)
 
         # wait until the results page appears
         results_text = driver.find_element_by_id('results')
+        result.s2c_result.end_time = datetime.datetime.now(pytz.utc)
         result.end_time = _record_time_when_element_displayed(results_text,
                                                               driver,
                                                               timeout=timeout)
@@ -209,11 +213,11 @@ def _populate_metric_values(result, driver):
             False if otherwise.
     """
     try:
-        result.c2s_throughput = driver.find_element_by_id('upload-speed').text
-        result = _validate_metric(result, result.c2s_throughput,
+        result.c2s_result.throughput = driver.find_element_by_id('upload-speed').text
+        result = _validate_metric(result, result.c2s_result.throughput,
                                   'c2s_throughput')
-        result.s2c_throughput = driver.find_element_by_id('download-speed').text
-        result = _validate_metric(result, result.s2c_throughput,
+        result.s2c_result.throughput = driver.find_element_by_id('download-speed').text
+        result = _validate_metric(result, result.s2c_result.throughput,
                                   's2c_throughput')
         result.latency = driver.find_element_by_id('latency').text
         result = _validate_metric(result, result.latency, 'latency')

--- a/client_wrapper/results.py
+++ b/client_wrapper/results.py
@@ -13,6 +13,22 @@
 # limitations under the License.
 
 
+class NdtSingleTestResult(object):
+    """Result of a single NDT test.
+
+    Attributes:
+        throughput: The final recorded throughput (in Mbps).
+        start_time: The datetime when the test began (or None if the test
+            never began).
+        end_time: The datetime when the test competed (or None if the test
+            never completed).
+    """
+
+    def __init__(self, throughput=None, start_time=None, end_time=None):
+        self.throughput = throughput
+        self.start_time = start_time
+        self.end_time = end_time
+
 class TestError(object):
     """Log message of an error encountered in the test.
 
@@ -34,8 +50,8 @@ class NdtResult(object):
             the driver pushed the 'Start Test' button).
         end_time: The datetime at which the tests completed (i.e. the time the
             results page loaded).
-        c2s_start_time: The NdtSingleResult for the c2s (upload) test.
-        s2c_start_time: The NdtSingleResult for the s2c (download) test.
+        c2s_result: The NdtSingleResult for the c2s (upload) test.
+        s2c_result: The NdtSingleResult for the s2c (download) test.
         latency: The reported latency (in milliseconds).
         c2s_throughput: The reported upload (c2s) throughput (in kb/s).
         s2c_throughput: The reported download (s2c) throughput (in kb/s).

--- a/client_wrapper/results.py
+++ b/client_wrapper/results.py
@@ -29,6 +29,7 @@ class NdtSingleTestResult(object):
         self.start_time = start_time
         self.end_time = end_time
 
+
 class TestError(object):
     """Log message of an error encountered in the test.
 
@@ -53,8 +54,6 @@ class NdtResult(object):
         c2s_result: The NdtSingleResult for the c2s (upload) test.
         s2c_result: The NdtSingleResult for the s2c (download) test.
         latency: The reported latency (in milliseconds).
-        c2s_throughput: The reported upload (c2s) throughput (in kb/s).
-        s2c_throughput: The reported download (s2c) throughput (in kb/s).
         errors: a list of TestError objects representing any errors encountered
             during the tests (or an empty list if all tests were successful).
     """
@@ -62,20 +61,16 @@ class NdtResult(object):
     def __init__(self,
                  start_time,
                  end_time,
-                 c2s_start_time,
-                 s2c_start_time,
                  errors,
-                 latency=None,
-                 c2s_throughput=None,
-                 s2c_throughput=None):
+                 c2s_result=None,
+                 s2c_result=None,
+                 latency=None):
         self.start_time = start_time
         self.end_time = end_time
-        self.c2s_start_time = c2s_start_time
-        self.s2c_start_time = s2c_start_time
+        self.c2s_result = c2s_result
+        self.s2c_result = s2c_result
         self.errors = errors
         self.latency = latency
-        self.c2s_throughput = c2s_throughput
-        self.s2c_throughput = s2c_throughput
 
     def __str__(self):
         return 'NDT Results:\n Start Time: %s,\n End Time: %s'\

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -129,12 +129,11 @@ class NdtHtml5SeleniumDriverGeneralTest(unittest.TestCase):
         # and ending at 2016-1-1 8:04:00. These will be the values that our
         # mock datetime.now() function returns.
         base_date = datetime.datetime(2016, 1, 1, 8, 0, 0, tzinfo=pytz.utc)
-        dates = [base_date + datetime.timedelta(0, 60) * x for x in range(5)]
+        dates = [base_date + datetime.timedelta(0, 60) * x for x in range(6)]
 
         with mock.patch.object(html5_driver.datetime,
                                'datetime',
                                autospec=True) as mocked_datetime:
-
             mocked_datetime.now.side_effect = dates
             test_results = html5_driver.NdtHtml5SeleniumDriver(
                 browser='firefox',
@@ -151,7 +150,7 @@ class NdtHtml5SeleniumDriverGeneralTest(unittest.TestCase):
                                            0,
                                            0,
                                            tzinfo=pytz.utc))
-        self.assertEqual(test_results.c2s_start_time,
+        self.assertEqual(test_results.c2s_result.start_time,
                          datetime.datetime(2016,
                                            1,
                                            1,
@@ -159,12 +158,12 @@ class NdtHtml5SeleniumDriverGeneralTest(unittest.TestCase):
                                            1,
                                            0,
                                            tzinfo=pytz.utc))
-        self.assertEqual(test_results.s2c_start_time,
+        self.assertEqual(test_results.s2c_result.start_time,
                          datetime.datetime(2016,
                                            1,
                                            1,
                                            8,
-                                           2,
+                                           3,
                                            0,
                                            tzinfo=pytz.utc))
         self.assertEqual(test_results.end_time,
@@ -172,7 +171,7 @@ class NdtHtml5SeleniumDriverGeneralTest(unittest.TestCase):
                                            1,
                                            1,
                                            8,
-                                           3,
+                                           5,
                                            0,
                                            tzinfo=pytz.utc))
 

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -100,81 +100,6 @@ class NdtHtml5SeleniumDriverGeneralTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             selenium_driver.perform_test()
 
-    @freezegun.freeze_time('2016-01-01', tz_offset=0)
-    def test_ndt_test_results_records_todays_times(self):
-        # When we patch datetime so it shows our current date as 2016-01-01
-        self.assertEqual(datetime.datetime.now(), datetime.datetime(2016, 1, 1))
-
-        with mock.patch.object(html5_driver.ui, 'WebDriverWait', autospec=True):
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
-                browser='firefox',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1).perform_test()
-
-        # Then the readings for our test start and end times occur within
-        # today's date
-        self.assertEqual(test_results.start_time,
-                         datetime.datetime(2016,
-                                           1,
-                                           1,
-                                           tzinfo=pytz.utc))
-        self.assertEqual(test_results.end_time,
-                         datetime.datetime(2016,
-                                           1,
-                                           1,
-                                           tzinfo=pytz.utc))
-
-    def test_ndt_test_results_increments_time_correctly(self):
-        # Create a list of times every minute starting at 2016-1-1 8:00:00
-        # and ending at 2016-1-1 8:04:00. These will be the values that our
-        # mock datetime.now() function returns.
-        base_date = datetime.datetime(2016, 1, 1, 8, 0, 0, tzinfo=pytz.utc)
-        dates = [base_date + datetime.timedelta(0, 60) * x for x in range(6)]
-
-        with mock.patch.object(html5_driver.datetime,
-                               'datetime',
-                               autospec=True) as mocked_datetime:
-            mocked_datetime.now.side_effect = dates
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
-                browser='firefox',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1).perform_test()
-
-        # And the sequence of returned values follows the expected timeline
-        # that the readings are taken in.
-        self.assertEqual(test_results.start_time,
-                         datetime.datetime(2016,
-                                           1,
-                                           1,
-                                           8,
-                                           0,
-                                           0,
-                                           tzinfo=pytz.utc))
-        self.assertEqual(test_results.c2s_result.start_time,
-                         datetime.datetime(2016,
-                                           1,
-                                           1,
-                                           8,
-                                           1,
-                                           0,
-                                           tzinfo=pytz.utc))
-        self.assertEqual(test_results.s2c_result.start_time,
-                         datetime.datetime(2016,
-                                           1,
-                                           1,
-                                           8,
-                                           3,
-                                           0,
-                                           tzinfo=pytz.utc))
-        self.assertEqual(test_results.end_time,
-                         datetime.datetime(2016,
-                                           1,
-                                           1,
-                                           8,
-                                           5,
-                                           0,
-                                           tzinfo=pytz.utc))
-
 
 class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
 
@@ -243,13 +168,6 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
         """A valid (numeric) latency results in an empty errors list."""
 
         # Mock so always returns a numeric value for a WebElement.text attribute
-        class NewWebElement(object):
-
-            def __init__(self):
-                self.text = '72'
-
-            def click(self):
-                pass
 
         class NewDriver(object):
 
@@ -260,10 +178,14 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
                 pass
 
             def find_element_by_id(self, id):
-                return NewWebElement()
+                if id == 'download-speed-units':
+                    return mock.Mock(text='Mb/s', autospec=True)
+                elif id == 'upload-speed-units':
+                    return mock.Mock(text='Mb/s', autospec=True)
+                return mock.Mock(text='72', autospec=True)
 
             def find_elements_by_xpath(self, xpath):
-                return [NewWebElement()]
+                return [mock.Mock(autospec=True)]
 
         with mock.patch.object(html5_driver.webdriver,
                                'Firefox',
@@ -283,13 +205,6 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
         """Test s2c speed converts from Gb/s to Mb/s correctly."""
 
         # If s2c speed is 72 Gb/s and c2s is speed is 34 in the browser
-        class NewWebElement(object):
-
-            def __init__(self, value):
-                self.text = value
-
-            def click(self):
-                pass
 
         class NewDriver(object):
 
@@ -301,14 +216,16 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
 
             def find_element_by_id(self, id):
                 if id == 'download-speed-units':
-                    return NewWebElement('Gb/s')
+                    return mock.Mock(text='Gb/s', autospec=True)
                 elif id == 'download-speed':
-                    return NewWebElement(72)
+                    return mock.Mock(text='72', autospec=True)
+                elif id == 'upload-speed-units':
+                    return mock.Mock(text='Mb/s', autospec=True)
                 else:
-                    return NewWebElement(34)
+                    return mock.Mock(text='34', autospec=True)
 
             def find_elements_by_xpath(self, xpath):
-                return [NewWebElement('')]
+                return [mock.Mock(autospec=True)]
 
         with mock.patch.object(html5_driver.webdriver,
                                'Firefox',
@@ -331,13 +248,6 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
         """Test c2s speed converts from kb/s to Mb/s correctly."""
 
         # If c2s speed is 72 kb/s and s2c speed is 34 in the browser
-        class NewWebElement(object):
-
-            def __init__(self, value):
-                self.text = value
-
-            def click(self):
-                pass
 
         class NewDriver(object):
 
@@ -349,14 +259,16 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
 
             def find_element_by_id(self, id):
                 if id == 'upload-speed-units':
-                    return NewWebElement('kb/s')
+                    return mock.Mock(text='kb/s', autospec=True)
                 elif id == 'upload-speed':
-                    return NewWebElement(72)
+                    return mock.Mock(text='72', autospec=True)
+                elif id == 'download-speed-units':
+                    return mock.Mock(text='Mb/s', autospec=True)
                 else:
-                    return NewWebElement(34)
+                    return mock.Mock(text='34', autospec=True)
 
             def find_elements_by_xpath(self, xpath):
-                return [NewWebElement('')]
+                return [mock.Mock(autospec=True)]
 
         with mock.patch.object(html5_driver.webdriver,
                                'Firefox',
@@ -374,6 +286,134 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
         self.assertEqual(test_results.s2c_result.throughput, 34)
         # And an error object is not contained in the list
         self.assertEqual(len(test_results.errors), 0)
+
+    @freezegun.freeze_time('2016-01-01', tz_offset=0)
+    def test_ndt_test_results_records_todays_times(self):
+
+        class NewDriver(object):
+
+            def get(self, url):
+                pass
+
+            def close(self):
+                pass
+
+            def find_element_by_id(self, id):
+                if id == 'upload-speed-units':
+                    return mock.Mock(text='kb/s', autospec=True)
+                elif id == 'download-speed-units':
+                    return mock.Mock(text='Mb/s', autospec=True)
+                elif id == 'upload-speed' or 'download-speed':
+                    return mock.Mock(text='72', autospec=True)
+                else:
+                    return mock.Mock(autospec=True)
+
+            def find_elements_by_xpath(self, xpath):
+                return [mock.Mock(autospec=True)]
+        # When we patch datetime so it shows our current date as 2016-01-01
+        self.assertEqual(datetime.datetime.now(), datetime.datetime(2016, 1, 1))
+
+        with mock.patch.object(html5_driver.webdriver,
+                               'Firefox',
+                               autospec=True,
+                               return_value=NewDriver()):
+
+            test_results = html5_driver.NdtHtml5SeleniumDriver(
+                browser='firefox',
+                url='http://ndt.mock-server.com:7123/',
+                timeout=1000).perform_test()
+
+        # Then the readings for our test start and end times occur within
+        # today's date
+        self.assertEqual(test_results.start_time,
+                         datetime.datetime(2016,
+                                           1,
+                                           1,
+                                           tzinfo=pytz.utc))
+        self.assertEqual(test_results.end_time,
+                         datetime.datetime(2016,
+                                           1,
+                                           1,
+                                           tzinfo=pytz.utc))
+
+    def test_ndt_test_results_increments_time_correctly(self):
+        # Create a list of times every minute starting at 2016-1-1 8:00:00
+        # and ending at 2016-1-1 8:04:00. These will be the values that our
+        # mock datetime.now() function returns.
+        base_date = datetime.datetime(2016, 1, 1, 8, 0, 0, tzinfo=pytz.utc)
+        dates = [base_date + datetime.timedelta(0, 60) * x for x in range(6)]
+
+        class NewDriver(object):
+
+            def get(self, url):
+                pass
+
+            def close(self):
+                pass
+
+            def find_element_by_id(self, id):
+                if id == 'upload-speed-units':
+                    return mock.Mock(text='kb/s', autospec=True)
+                elif id == 'upload-speed':
+                    return mock.Mock(text='72', autospec=True)
+                elif id == 'download-speed-units':
+                    return mock.Mock(text='Mb/s', autospec=True)
+                else:
+                    return mock.Mock(text='34', autospec=True)
+
+            def find_elements_by_xpath(self, xpath):
+                return [mock.Mock(autospec=True)]
+
+        mock_driver = mock.patch.object(html5_driver.webdriver,
+                                        'Firefox',
+                                        autospec=True,
+                                        return_value=NewDriver())
+        mock_driver.start()
+        with mock.patch.object(html5_driver.datetime,
+                               'datetime',
+                               autospec=True) as mocked_datetime:
+            mocked_datetime.now.side_effect = dates
+
+            test_results = html5_driver.NdtHtml5SeleniumDriver(
+                browser='firefox',
+                url='http://ndt.mock-server.com:7123/',
+                timeout=1).perform_test()
+        mock_driver.stop()
+
+        # And the sequence of returned values follows the expected timeline
+        # that the readings are taken in.
+        self.assertEqual(test_results.start_time,
+                         datetime.datetime(2016,
+                                           1,
+                                           1,
+                                           8,
+                                           0,
+                                           0,
+                                           tzinfo=pytz.utc))
+        self.assertEqual(test_results.c2s_result.start_time,
+                         datetime.datetime(2016,
+                                           1,
+                                           1,
+                                           8,
+                                           1,
+                                           0,
+                                           tzinfo=pytz.utc))
+        self.assertEqual(test_results.s2c_result.start_time,
+                         datetime.datetime(2016,
+                                           1,
+                                           1,
+                                           8,
+                                           3,
+                                           0,
+                                           tzinfo=pytz.utc))
+        self.assertEqual(test_results.end_time,
+                         datetime.datetime(2016,
+                                           1,
+                                           1,
+                                           8,
+                                           5,
+                                           0,
+                                           tzinfo=pytz.utc))
 
 
 if __name__ == '__main__':

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -279,6 +279,50 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
         # And an error object is not contained in the list
         self.assertEqual(len(test_results.errors), 0)
 
+    def test_c2s_speed_conversion(self):
+        '''Test c2s speed converts from kb/s to Mb/s correctly.'''
+
+        # If c2s speed and s2c speed are 72 in the browser
+        # Mock so always returns a numeric value for a WebElement.text attribute
+        class NewWebElement(object):
+
+            def __init__(self):
+                self.text = '72'
+
+            def click(self):
+                pass
+
+        class NewDriver(object):
+
+            def get(self, url):
+                pass
+
+            def close(self):
+                pass
+
+            def find_element_by_id(self, id):
+                return NewWebElement()
+
+            def find_elements_by_xpath(self, xpath):
+                return [NewWebElement()]
+
+        with mock.patch.object(html5_driver.webdriver,
+                               'Firefox',
+                               autospec=True,
+                               return_value=NewDriver()):
+
+            test_results = html5_driver.NdtHtml5SeleniumDriver(
+                browser='firefox',
+                url='http://ndt.mock-server.com:7123/',
+                timeout=1000).perform_test()
+
+        # Then c2s is converted from kb/s to Mb/s
+        self.assertEqual(test_results.c2s_result.throughput, '0.072')
+        # And s2c is not
+        self.assertEqual(test_results.s2c_result.throughput, '72')
+        # And an error object is not contained in the list
+        self.assertEqual(len(test_results.errors), 0)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Implemented `NdtSingleTestResult` -- `NdtResult` now stores `NdtSingleTestResult` objects, rather than storing the values directly. Also converted values so they are in Mb/s where necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/6)
<!-- Reviewable:end -->
