### PR TITLE
Adding a JSON encoder for NdtResult

### DIFF
--- a/client_wrapper/result_encoder.py
+++ b/client_wrapper/result_encoder.py
@@ -19,33 +19,46 @@ import results
 
 
 class NdtResultEncoder(json.JSONEncoder):
-    """Encodes an NdtResult instance into JSON."""
+    """Encodes an NdtResult instance into JSON.
+
+    Given a populated NdtResult instance, serializes the result to JSON.
+
+    The encoder assumes that:
+
+    * NdtResult's required fields (those not documented as allowing None
+        values) are populated
+    * All populated fields are valid
+
+    In other words, it is caller's responsibility to pass valid data.
+    """
 
     def default(self, obj):
         if isinstance(obj, results.NdtResult):
-            return self._encode_ndt_result(obj)
+            return _encode_ndt_result(obj)
+        elif isinstance(obj, results.TestError):
+            return _encode_error(obj)
+        elif isinstance(obj, datetime.datetime):
+            return _encode_time(obj)
         return json.JSONEncoder.default(self, obj)
 
-    def _encode_ndt_result(self, result):
-        result_dict = {
-            'start_time': _encode_time(result.start_time),
-            'end_time': _encode_time(result.end_time),
-            'errors': _encode_errors(result.errors),
-        }
-        # TODO(mtlynch): Implement encoding for NdtResult's other fields.
 
-        return result_dict
+def _encode_ndt_result(result):
+    result_dict = {
+        'start_time': result.start_time,
+        'end_time': result.end_time,
+        'client': result.client,
+        'client_version': result.client_version,
+        'os': result.os,
+        'os_version': result.os_version,
+        'errors': result.errors,
+    }
+    # TODO(mtlynch): Implement encoding for NdtResult's other fields.
 
-
-def _encode_errors(errors):
-    return [_encode_error(e) for e in errors]
+    return result_dict
 
 
 def _encode_error(error):
-    return {
-        'timestamp': _encode_time(error.timestamp),
-        'message': error.message,
-    }
+    return {'timestamp': error.timestamp, 'message': error.message}
 
 
 def _encode_time(time):

--- a/client_wrapper/result_encoder.py
+++ b/client_wrapper/result_encoder.py
@@ -1,0 +1,52 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import json
+
+import results
+
+
+class NdtResultEncoder(json.JSONEncoder):
+    """Encodes an NdtResult instance into JSON."""
+
+    def default(self, obj):
+        if isinstance(obj, results.NdtResult):
+            return self._encode_ndt_result(obj)
+        return json.JSONEncoder.default(self, obj)
+
+    def _encode_ndt_result(self, result):
+        result_dict = {
+            'start_time': _encode_time(result.start_time),
+            'end_time': _encode_time(result.end_time),
+            'errors': _encode_errors(result.errors),
+        }
+        # TODO(mtlynch): Implement encoding for NdtResult's other fields.
+
+        return result_dict
+
+
+def _encode_errors(errors):
+    return [_encode_error(e) for e in errors]
+
+
+def _encode_error(error):
+    return {
+        'timestamp': _encode_time(error.timestamp),
+        'message': error.message,
+    }
+
+
+def _encode_time(time):
+    return datetime.datetime.strftime(time, '%Y-%m-%dT%H:%M:%S.%fZ')

--- a/client_wrapper/results.py
+++ b/client_wrapper/results.py
@@ -59,9 +59,9 @@ class NdtResult(object):
     """
 
     def __init__(self,
-                 start_time,
-                 end_time,
-                 errors,
+                 start_time=None,
+                 end_time=None,
+                 errors=[],
                  c2s_result=None,
                  s2c_result=None,
                  latency=None):

--- a/client_wrapper/results.py
+++ b/client_wrapper/results.py
@@ -51,11 +51,18 @@ class NdtResult(object):
             the driver pushed the 'Start Test' button).
         end_time: The datetime at which the tests completed (i.e. the time the
             results page loaded).
+        errors: A list of TestError objects representing any errors encountered
+            during the tests (or an empty list if all tests were successful).
         c2s_result: The NdtSingleResult for the c2s (upload) test.
         s2c_result: The NdtSingleResult for the s2c (download) test.
-        latency: The reported latency (in milliseconds).
-        errors: a list of TestError objects representing any errors encountered
-            during the tests (or an empty list if all tests were successful).
+        latency: The reported latency (in milliseconds) or None if the test did
+            not complete.
+        c2s_throughput: The reported upload (c2s) throughput (in kb/s).
+        s2c_throughput: The reported download (s2c) throughput (in kb/s).
+        os: Name of OS in which the test ran (e.g. "Windows").
+        os_version: OS version string (e.g. "10.0").
+        client: Shortname of the NDT client (e.g. "ndt_js").
+        client_version: Version string of the NDT client (e.g. "4.0.1").
     """
 
     def __init__(self,
@@ -71,6 +78,10 @@ class NdtResult(object):
         self.s2c_result = s2c_result
         self.errors = errors
         self.latency = latency
+        self.os = None
+        self.os_version = None
+        self.client = None
+        self.client_version = None
 
     def __str__(self):
         return 'NDT Results:\n Start Time: %s,\n End Time: %s'\

--- a/tests/test_result_encoder.py
+++ b/tests/test_result_encoder.py
@@ -1,0 +1,107 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import datetime
+import json
+import unittest
+
+import pytz
+
+from client_wrapper import result_encoder
+from client_wrapper import results
+
+
+class NdtResultEncoderTest(unittest.TestCase):
+
+    def setUp(self):
+        # Disable maxDiff, as diffing JSON can generate large diffs
+        self.maxDiff = None
+        self.encoder = result_encoder.NdtResultEncoder()
+
+    def assertJsonEqual(self, expected, actual):
+        self.assertDictEqual(json.loads(expected), json.loads(actual))
+
+    def test_encodes_correctly_when_only_required_fields_are_set(self):
+        result = results.NdtResult(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
+                                       pytz.utc))
+        encoded_expected = """
+{
+    "start_time": "2016-02-26T15:51:23.452234Z",
+    "end_time": "2016-02-26T15:59:33.284345Z",
+    "errors": []
+}"""
+
+        encoded_actual = self.encoder.encode(result)
+        self.assertJsonEqual(encoded_expected, encoded_actual)
+
+    def test_encodes_correctly_when_result_includes_one_error(self):
+        result = results.NdtResult(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
+                                       pytz.utc))
+        result.errors = [results.TestError(
+            datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
+            'mock error message 1')]
+        encoded_expected = """
+{
+    "start_time": "2016-02-26T15:51:23.452234Z",
+    "end_time": "2016-02-26T15:59:33.284345Z",
+    "errors": [
+        {
+            "timestamp": "2016-02-26T15:53:29.123456Z",
+            "message": "mock error message 1"
+        }
+    ]
+}"""
+
+        encoded_actual = self.encoder.encode(result)
+        self.assertJsonEqual(encoded_expected, encoded_actual)
+
+    def test_encodes_correctly_when_result_includes_two_errors(self):
+        result = results.NdtResult(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
+                                       pytz.utc))
+        result.errors = [
+            results.TestError(
+                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
+                'mock error message 1'),
+            results.TestError(
+                datetime.datetime(2016, 2, 26, 15, 53, 29, 654321, pytz.utc),
+                'mock error message 2')
+        ]
+        encoded_expected = """
+{
+    "start_time": "2016-02-26T15:51:23.452234Z",
+    "end_time": "2016-02-26T15:59:33.284345Z",
+    "errors": [
+        {
+            "timestamp": "2016-02-26T15:53:29.123456Z",
+            "message": "mock error message 1"
+        },
+        {
+            "timestamp": "2016-02-26T15:53:29.654321Z",
+            "message": "mock error message 2"
+        }
+    ]
+}"""
+
+        encoded_actual = self.encoder.encode(result)
+        self.assertJsonEqual(encoded_expected, encoded_actual)

--- a/tests/test_result_encoder.py
+++ b/tests/test_result_encoder.py
@@ -23,6 +23,16 @@ from client_wrapper import result_encoder
 from client_wrapper import results
 
 
+def create_ndt_result(start_time, end_time, client, client_version, os,
+                      os_version):
+    result = results.NdtResult(start_time=start_time, end_time=end_time)
+    result.client = client
+    result.client_version = client_version
+    result.os = os
+    result.os_version = os_version
+    return result
+
+
 class NdtResultEncoderTest(unittest.TestCase):
 
     def setUp(self):
@@ -34,15 +44,23 @@ class NdtResultEncoderTest(unittest.TestCase):
         self.assertDictEqual(json.loads(expected), json.loads(actual))
 
     def test_encodes_correctly_when_only_required_fields_are_set(self):
-        result = results.NdtResult(
+        result = create_ndt_result(
             start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
                                          pytz.utc),
             end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
-                                       pytz.utc))
+                                       pytz.utc),
+            client='mock_client',
+            client_version='mock_client_version',
+            os='mock_os',
+            os_version='mock_os_version')
         encoded_expected = """
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
     "end_time": "2016-02-26T15:59:33.284345Z",
+    "client": "mock_client",
+    "client_version": "mock_client_version",
+    "os": "mock_os",
+    "os_version": "mock_os_version",
     "errors": []
 }"""
 
@@ -50,11 +68,15 @@ class NdtResultEncoderTest(unittest.TestCase):
         self.assertJsonEqual(encoded_expected, encoded_actual)
 
     def test_encodes_correctly_when_result_includes_one_error(self):
-        result = results.NdtResult(
+        result = create_ndt_result(
             start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
                                          pytz.utc),
             end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
-                                       pytz.utc))
+                                       pytz.utc),
+            client='mock_client',
+            client_version='mock_client_version',
+            os='mock_os',
+            os_version='mock_os_version')
         result.errors = [results.TestError(
             datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
             'mock error message 1')]
@@ -62,6 +84,10 @@ class NdtResultEncoderTest(unittest.TestCase):
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
     "end_time": "2016-02-26T15:59:33.284345Z",
+    "client": "mock_client",
+    "client_version": "mock_client_version",
+    "os": "mock_os",
+    "os_version": "mock_os_version",
     "errors": [
         {
             "timestamp": "2016-02-26T15:53:29.123456Z",
@@ -74,11 +100,15 @@ class NdtResultEncoderTest(unittest.TestCase):
         self.assertJsonEqual(encoded_expected, encoded_actual)
 
     def test_encodes_correctly_when_result_includes_two_errors(self):
-        result = results.NdtResult(
+        result = create_ndt_result(
             start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
                                          pytz.utc),
             end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
-                                       pytz.utc))
+                                       pytz.utc),
+            client='mock_client',
+            client_version='mock_client_version',
+            os='mock_os',
+            os_version='mock_os_version')
         result.errors = [
             results.TestError(
                 datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
@@ -91,6 +121,10 @@ class NdtResultEncoderTest(unittest.TestCase):
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
     "end_time": "2016-02-26T15:59:33.284345Z",
+    "client": "mock_client",
+    "client_version": "mock_client_version",
+    "os": "mock_os",
+    "os_version": "mock_os_version",
     "errors": [
         {
             "timestamp": "2016-02-26T15:53:29.123456Z",


### PR DESCRIPTION
This adds a partial implementation of NdtResultEncoder that encodes test
start time, end time, and errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/7)
<!-- Reviewable:end -->
