### PR TITLE
Refactor name constants into a specific name module

### DIFF
--- a/client_wrapper/client_wrapper.py
+++ b/client_wrapper/client_wrapper.py
@@ -15,12 +15,11 @@
 import argparse
 
 import html5_driver
-
-NDT_HTML5_CLIENT = 'ndt_js'
+import names
 
 
 def main(args):
-    if args.client == NDT_HTML5_CLIENT:
+    if args.client == names.NDT_HTML5:
         driver = html5_driver.NdtHtml5SeleniumDriver(args.browser,
                                                      args.client_url,
                                                      timeout=20)
@@ -46,7 +45,7 @@ if __name__ == '__main__':
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--client',
                         help='NDT client implementation to run',
-                        choices=(NDT_HTML5_CLIENT,),
+                        choices=(names.NDT_HTML5,),
                         required=True)
     parser.add_argument('--browser',
                         help='Browser to run under (for browser-based client)',

--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -21,6 +21,7 @@ from selenium.webdriver.support import ui
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.common import exceptions
 
+import names
 import results
 
 
@@ -78,9 +79,9 @@ def _create_browser(browser):
         An instance of a Selenium webdriver browser class corresponding to
         the specified browser.
     """
-    if browser == 'firefox':
+    if browser == names.FIREFOX:
         return webdriver.Firefox()
-    if browser in ['chrome', 'edge', 'safari']:
+    if browser in [names.CHROME, names.EDGE, names.SAFARI]:
         raise NotImplementedError
     raise ValueError('Invalid browser specified: %s' % browser)
 

--- a/client_wrapper/names.py
+++ b/client_wrapper/names.py
@@ -1,0 +1,30 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Defines string constant for different names used throughout the system.
+
+This module defines the constant names of different strings used throughout the
+testing system to identify NDT clients, browsers, and operating systems.
+"""
+
+# NDT client shortnames
+NDT_HTML5 = 'ndt_js'  # Official NDT HTML5 reference client
+
+# Browser name constants
+FIREFOX = 'firefox'
+CHROME = 'chrome'
+EDGE = 'edge'
+SAFARI = 'safari'
+
+# OS shortnames
+# TODO(mtlynch): Add OS shortnames as we add code that relies on each name.


### PR DESCRIPTION
This change pulls all the name constants (for NDT clients, browsers, OSes)
into a separate file of just constants. This eliminates string duplication
and reduces the risk of string mismatches (e.g. 'ndtjs' vs 'ndt_js').

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/8)
<!-- Reviewable:end -->
