### PR TITLE
Adding support for OS and browser canonicalization

### DIFF
--- a/client_wrapper/canonicalize.py
+++ b/client_wrapper/canonicalize.py
@@ -1,0 +1,86 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import names
+
+
+class Error(Exception):
+    pass
+
+
+class UnsupportedPlatformError(Error):
+    """Indicates an unrecognized OS platform."""
+    pass
+
+
+class UnrecognizedVersionStringError(Error):
+    """Indicates an unrecognized version string."""
+    pass
+
+
+def os_to_shortname(os, os_version):
+    """Converts an OS name and version to its shortname.
+
+    Given an OS name and OS version, return the OS shortname (e.g. 'win10').
+
+    Args:
+        os: The OS platform name (e.g. "Windows" or "Ubuntu").
+        os_version: The version string for the platform in the form x.y where x
+            is the major version and y is the minor version.
+
+    Returns:
+        The os shortname for the OS and version.
+
+    Raises:
+        UnsupportedPlatformError if the caller specifies an OS and version
+        combination that does not have a known shortname.
+    """
+    shortname_map = {
+        #TODO(mtlynch): Check whether this is the right version string for
+        # Win10.
+        'Windows-10.0': names.WINDOWS_10,
+        'Ubuntu-14.04': names.UBUNTU_14,
+        #TODO(mtlynch): Check whether this is the right version string for
+        # El Capitan.
+        'OSX-10.11': names.OSX_CAPITAN,
+    }
+    key = '%s-%s' % (os, os_version)
+    try:
+        return shortname_map[key]
+    except KeyError:
+        raise UnsupportedPlatformError('Unsupported OS platform: %s v%s' %
+                                       (os, os_version))
+
+
+def browser_to_canonical_name(browser, browser_version):
+    """Converts a browser and version to its canonical name.
+
+    Converts a browser to the format of "[name]_v[major version]", e.g.
+    "firefox_v49".
+
+    Args:
+        browser: Browser name to convert to canonical name (e.g. "Firefox" or
+            "Edge").
+        browser_version: Browser version string. This must contain at least one
+            dot separator to separate the major version number from the rest of
+            the version string (e.g. "1.56").
+
+    Returns:
+        Returns the browser in shortname form, e.g. "firefox_v49".
+    """
+    version_parts = browser_version.split('.')
+    if len(version_parts) < 2:
+        raise UnrecognizedVersionStringError(
+            'Version string in unrecognized format: %s', browser_version)
+    return '%s_v%s' % (browser, version_parts[0])

--- a/client_wrapper/canonicalize.py
+++ b/client_wrapper/canonicalize.py
@@ -53,7 +53,7 @@ def os_to_shortname(os, os_version):
         'Ubuntu-14.04': names.UBUNTU_14,
         #TODO(mtlynch): Check whether this is the right version string for
         # El Capitan.
-        'OSX-10.11': names.OSX_CAPITAN,
+        'OSX-10.11': names.OSX_10_11,
     }
     key = '%s-%s' % (os, os_version)
     try:
@@ -66,21 +66,21 @@ def os_to_shortname(os, os_version):
 def browser_to_canonical_name(browser, browser_version):
     """Converts a browser and version to its canonical name.
 
-    Converts a browser to the format of "[name]_v[major version]", e.g.
-    "firefox_v49".
+    Converts a browser to the format of "[name][major version]", e.g.
+    "firefox49".
 
     Args:
-        browser: Browser name to convert to canonical name (e.g. "Firefox" or
-            "Edge").
+        browser: Browser name to convert to canonical name (e.g. "firefox" or
+            "edge").
         browser_version: Browser version string. This must contain at least one
             dot separator to separate the major version number from the rest of
             the version string (e.g. "1.56").
 
     Returns:
-        Returns the browser in shortname form, e.g. "firefox_v49".
+        Returns the browser in shortname form, e.g. "firefox49".
     """
     version_parts = browser_version.split('.')
     if len(version_parts) < 2:
         raise UnrecognizedVersionStringError(
             'Version string in unrecognized format: %s', browser_version)
-    return '%s_v%s' % (browser, version_parts[0])
+    return browser + version_parts[0]

--- a/client_wrapper/names.py
+++ b/client_wrapper/names.py
@@ -29,4 +29,4 @@ SAFARI = 'safari'
 # OS shortnames
 WINDOWS_10 = 'win10'
 UBUNTU_14 = 'ubuntu14.04'
-OSX_CAPITAN = 'osx_capitan'
+OSX_10_11 = 'osx10.11'

--- a/client_wrapper/names.py
+++ b/client_wrapper/names.py
@@ -27,4 +27,6 @@ EDGE = 'edge'
 SAFARI = 'safari'
 
 # OS shortnames
-# TODO(mtlynch): Add OS shortnames as we add code that relies on each name.
+WINDOWS_10 = 'win10'
+UBUNTU_14 = 'ubuntu14.04'
+OSX_CAPITAN = 'osx_capitan'

--- a/tests/test_canonicalize.py
+++ b/tests/test_canonicalize.py
@@ -26,7 +26,7 @@ class CanonicalizeTest(unittest.TestCase):
                          canonicalize.os_to_shortname('Windows', '10.0'))
         self.assertEqual(names.UBUNTU_14,
                          canonicalize.os_to_shortname('Ubuntu', '14.04'))
-        self.assertEqual(names.OSX_CAPITAN,
+        self.assertEqual(names.OSX_10_11,
                          canonicalize.os_to_shortname('OSX', '10.11'))
 
     def test_os_to_shortname_raises_error_on_unsupported_platforms(self):
@@ -41,16 +41,16 @@ class CanonicalizeTest(unittest.TestCase):
 
     def test_browser_to_canonical_name_creates_valid_browser_strings(self):
         self.assertEqual(
-            'chrome_v49',
+            'chrome49',
             canonicalize.browser_to_canonical_name(names.CHROME, '49.0.2623'))
         self.assertEqual(
-            'firefox_v45',
+            'firefox45',
             canonicalize.browser_to_canonical_name(names.FIREFOX, '45.0'))
         self.assertEqual(
-            'edge_v25',
+            'edge25',
             canonicalize.browser_to_canonical_name(names.EDGE, '25.10586.0.0'))
         self.assertEqual(
-            'safari_v9',
+            'safari9',
             canonicalize.browser_to_canonical_name(names.SAFARI, '9.03'))
 
     def test_browser_to_canonical_name_raise_error_on_bad_version_strings(self):

--- a/tests/test_canonicalize.py
+++ b/tests/test_canonicalize.py
@@ -1,0 +1,61 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import unittest
+
+from client_wrapper import canonicalize
+from client_wrapper import names
+
+
+class CanonicalizeTest(unittest.TestCase):
+
+    def test_os_to_shortname_converts_recognized_platforms(self):
+        self.assertEqual(names.WINDOWS_10,
+                         canonicalize.os_to_shortname('Windows', '10.0'))
+        self.assertEqual(names.UBUNTU_14,
+                         canonicalize.os_to_shortname('Ubuntu', '14.04'))
+        self.assertEqual(names.OSX_CAPITAN,
+                         canonicalize.os_to_shortname('OSX', '10.11'))
+
+    def test_os_to_shortname_raises_error_on_unsupported_platforms(self):
+        with self.assertRaises(canonicalize.UnsupportedPlatformError):
+            canonicalize.os_to_shortname('SpaghettiOS', '6.7')
+        with self.assertRaises(canonicalize.UnsupportedPlatformError):
+            canonicalize.os_to_shortname('Windows', '7.0')
+        with self.assertRaises(canonicalize.UnsupportedPlatformError):
+            canonicalize.os_to_shortname('OSX', '5.6')
+        with self.assertRaises(canonicalize.UnsupportedPlatformError):
+            canonicalize.os_to_shortname('Ubuntu', '10.04')
+
+    def test_browser_to_canonical_name_creates_valid_browser_strings(self):
+        self.assertEqual(
+            'chrome_v49',
+            canonicalize.browser_to_canonical_name(names.CHROME, '49.0.2623'))
+        self.assertEqual(
+            'firefox_v45',
+            canonicalize.browser_to_canonical_name(names.FIREFOX, '45.0'))
+        self.assertEqual(
+            'edge_v25',
+            canonicalize.browser_to_canonical_name(names.EDGE, '25.10586.0.0'))
+        self.assertEqual(
+            'safari_v9',
+            canonicalize.browser_to_canonical_name(names.SAFARI, '9.03'))
+
+    def test_browser_to_canonical_name_raise_error_on_bad_version_strings(self):
+        # Version string must contain a dot separator
+        with self.assertRaises(canonicalize.UnrecognizedVersionStringError):
+            canonicalize.browser_to_canonical_name(names.EDGE, 'banana')
+        with self.assertRaises(canonicalize.UnrecognizedVersionStringError):
+            canonicalize.browser_to_canonical_name(names.CHROME, '6')


### PR DESCRIPTION
This adds functionality to canonicalize OS and browser names into common,
canonical formats used in client_wrapper's output filenames.

See the [design doc section](https://docs.google.com/document/d/16b0EesUFrt8eZ1T_f0wPkhC3qkG3W0o8RT4K5_8I9KE/edit#heading=h.khz5pfiy3nt4) on output filenames for additional context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/9)
<!-- Reviewable:end -->