### PR TITLE
Adding support for result filename generation

### DIFF
--- a/client_wrapper/filename.py
+++ b/client_wrapper/filename.py
@@ -1,0 +1,61 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import canonicalize
+
+
+class Error(Exception):
+    pass
+
+
+class FilenameCreationError(Error):
+    pass
+
+
+_FILENAME_FORMAT = ('{os}-{browser}-{client}-{timestamp}-{type}.{extension}')
+
+
+def create_result_filename(result):
+    """Create an output filename based on an NdtResult.
+
+    Args:
+        result: NdtResult instance for which to create an output filename.
+
+    Returns:
+        An output filename representing the result, for example:
+
+            win10-chrome49-ndt_js-2016-02-26T155423Z-results.json
+    """
+    if not result.browser:
+        raise NotImplementedError(
+            'support for non-browser test filenames is not yet implemented')
+    try:
+        os = canonicalize.os_to_shortname(result.os, result.os_version)
+        browser = canonicalize.browser_to_canonical_name(result.browser,
+                                                         result.browser_version)
+    except canonicalize.Error as e:
+        raise FilenameCreationError(
+            'Could not generate filename for NDT result: %s', e.message)
+    client = result.client
+    timestamp = _format_time(result.start_time)
+    return _FILENAME_FORMAT.format(os=os,
+                                   browser=browser,
+                                   client=client,
+                                   timestamp=timestamp,
+                                   type='results',
+                                   extension='json')
+
+
+def _format_time(timestamp):
+    return timestamp.strftime('%Y-%m-%dT%H%M%SZ')

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -89,7 +89,7 @@ class FilenamesTest(unittest.TestCase):
         with self.assertRaises(filename.FilenameCreationError):
             get_result_filename(os='Ubuntu',
                                 os_version='14.04',
-                                browser='firefox',
+                                browser=names.FIREFOX,
                                 browser_version='invalid version',
                                 client=names.NDT_HTML5,
                                 start_time=datetime.datetime(2015, 9, 17, 8, 9,

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -1,0 +1,96 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import datetime
+import unittest
+
+import pytz
+
+from client_wrapper import filename
+from client_wrapper import names
+from client_wrapper import results
+
+
+def get_result_filename(os, os_version, browser, browser_version, client,
+                        start_time):
+    """Creates an NdtResult with the given values and returns its filename."""
+    result = results.NdtResult(start_time=start_time)
+    result.os = os
+    result.os_version = os_version
+    result.client = client
+    result.browser = browser
+    result.browser_version = browser_version
+    return filename.create_result_filename(result)
+
+
+class FilenamesTest(unittest.TestCase):
+
+    def test_creates_correct_result_filename_for_valid_browser_based_tests(
+            self):
+        self.assertEqual(
+            'win10-chrome49-ndt_js-2016-02-26T155423Z-results.json',
+            get_result_filename(os='Windows',
+                                os_version='10.0',
+                                browser=names.CHROME,
+                                browser_version='49.0.2623',
+                                client=names.NDT_HTML5,
+                                start_time=datetime.datetime(
+                                    2016, 2, 26, 15, 54, 23, 0, pytz.utc)))
+        self.assertEqual(
+            'osx10.11-safari9-ndt_js-2017-03-29T042116Z-results.json',
+            get_result_filename(os='OSX',
+                                os_version='10.11',
+                                browser=names.SAFARI,
+                                browser_version='9.0.3',
+                                client=names.NDT_HTML5,
+                                start_time=datetime.datetime(2017, 3, 29, 4, 21,
+                                                             16, 0, pytz.utc)))
+        self.assertEqual(
+            'ubuntu14.04-firefox45-ndt_js-2015-09-17T080949Z-results.json',
+            get_result_filename(os='Ubuntu',
+                                os_version='14.04',
+                                browser=names.FIREFOX,
+                                browser_version='45.0',
+                                client=names.NDT_HTML5,
+                                start_time=datetime.datetime(2015, 9, 17, 8, 9,
+                                                             49, 0, pytz.utc)))
+
+    def test_creates_correct_result_filename_for_valid_non_browser_tests(self):
+        with self.assertRaises(NotImplementedError):
+            get_result_filename(os='Ubuntu',
+                                os_version='14.04',
+                                browser=None,
+                                browser_version=None,
+                                client='future client',
+                                start_time=datetime.datetime(2015, 9, 17, 8, 9,
+                                                             49, 0, pytz.utc))
+
+    def test_raises_error_on_invalid_ndt_results(self):
+        with self.assertRaises(filename.FilenameCreationError):
+            get_result_filename(os='invalid OS',
+                                os_version='14.04',
+                                browser=names.FIREFOX,
+                                browser_version='45.0',
+                                client=names.NDT_HTML5,
+                                start_time=datetime.datetime(2015, 9, 17, 8, 9,
+                                                             49, 0, pytz.utc))
+        with self.assertRaises(filename.FilenameCreationError):
+            get_result_filename(os='Ubuntu',
+                                os_version='14.04',
+                                browser='firefox',
+                                browser_version='invalid version',
+                                client=names.NDT_HTML5,
+                                start_time=datetime.datetime(2015, 9, 17, 8, 9,
+                                                             49, 0, pytz.utc))


### PR DESCRIPTION
Adds a filename module that generates output filenames based on the values
of an NdtResult instance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/13)
<!-- Reviewable:end -->
