### PR TITLE
Completing implementation of NdtResultEncoder

### DIFF
--- a/client_wrapper/result_encoder.py
+++ b/client_wrapper/result_encoder.py
@@ -52,7 +52,28 @@ def _encode_ndt_result(result):
         'os_version': result.os_version,
         'errors': result.errors,
     }
-    # TODO(mtlynch): Implement encoding for NdtResult's other fields.
+    # Flatten out c2s result so that all fields are in the root of the overall
+    # NDT result.
+    if result.c2s_result:
+        result_dict['c2s_start_time'] = result.c2s_result.start_time
+        result_dict['c2s_end_time'] = result.c2s_result.end_time
+        result_dict['c2s_throughput'] = result.c2s_result.throughput
+    else:
+        result_dict['c2s_start_time'] = None
+        result_dict['c2s_end_time'] = None
+        result_dict['c2s_throughput'] = None
+
+    # Flatten out s2c result so that all fields are in the root of the overall
+    # NDT result.
+    if result.s2c_result:
+        result_dict['s2c_start_time'] = result.s2c_result.start_time
+        result_dict['s2c_end_time'] = result.s2c_result.end_time
+        result_dict['s2c_throughput'] = result.s2c_result.throughput
+    else:
+        result_dict['s2c_start_time'] = None
+        result_dict['s2c_end_time'] = None
+        result_dict['s2c_throughput'] = None
+    result_dict['latency'] = result.latency
 
     return result_dict
 

--- a/client_wrapper/results.py
+++ b/client_wrapper/results.py
@@ -53,12 +53,12 @@ class NdtResult(object):
             results page loaded).
         errors: A list of TestError objects representing any errors encountered
             during the tests (or an empty list if all tests were successful).
-        c2s_result: The NdtSingleResult for the c2s (upload) test.
-        s2c_result: The NdtSingleResult for the s2c (download) test.
+        c2s_result: The NdtSingleResult for the c2s (upload) test (or None if no
+            result was recorded).
+        s2c_result: The NdtSingleResult for the s2c (download) test (or None if
+            no result was recorded).
         latency: The reported latency (in milliseconds) or None if the test did
             not complete.
-        c2s_throughput: The reported upload (c2s) throughput (in kb/s).
-        s2c_throughput: The reported download (s2c) throughput (in kb/s).
         os: Name of OS in which the test ran (e.g. "Windows").
         os_version: OS version string (e.g. "10.0").
         client: Shortname of the NDT client (e.g. "ndt_js").

--- a/tests/test_result_encoder.py
+++ b/tests/test_result_encoder.py
@@ -61,6 +61,13 @@ class NdtResultEncoderTest(unittest.TestCase):
     "client_version": "mock_client_version",
     "os": "mock_os",
     "os_version": "mock_os_version",
+    "c2s_start_time": null,
+    "c2s_end_time": null,
+    "c2s_throughput": null,
+    "s2c_start_time": null,
+    "s2c_end_time": null,
+    "s2c_throughput": null,
+    "latency": null,
     "errors": []
 }"""
 
@@ -88,6 +95,13 @@ class NdtResultEncoderTest(unittest.TestCase):
     "client_version": "mock_client_version",
     "os": "mock_os",
     "os_version": "mock_os_version",
+    "c2s_start_time": null,
+    "c2s_end_time": null,
+    "c2s_throughput": null,
+    "s2c_start_time": null,
+    "s2c_end_time": null,
+    "s2c_throughput": null,
+    "latency": null,
     "errors": [
         {
             "timestamp": "2016-02-26T15:53:29.123456Z",
@@ -125,6 +139,13 @@ class NdtResultEncoderTest(unittest.TestCase):
     "client_version": "mock_client_version",
     "os": "mock_os",
     "os_version": "mock_os_version",
+    "c2s_start_time": null,
+    "c2s_end_time": null,
+    "c2s_throughput": null,
+    "s2c_start_time": null,
+    "s2c_end_time": null,
+    "s2c_throughput": null,
+    "latency": null,
     "errors": [
         {
             "timestamp": "2016-02-26T15:53:29.123456Z",
@@ -133,6 +154,264 @@ class NdtResultEncoderTest(unittest.TestCase):
         {
             "timestamp": "2016-02-26T15:53:29.654321Z",
             "message": "mock error message 2"
+        }
+    ]
+}"""
+
+        encoded_actual = self.encoder.encode(result)
+        self.assertJsonEqual(encoded_expected, encoded_actual)
+
+    def test_encodes_fully_populated_result_correctly(self):
+        result = create_ndt_result(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
+                                       pytz.utc),
+            client='mock_client',
+            client_version='mock_client_version',
+            os='mock_os',
+            os_version='mock_os_version')
+        result.c2s_result = results.NdtSingleTestResult(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 24, 123456,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 51, 34, 123456,
+                                       pytz.utc),
+            throughput=10.127)
+        result.s2c_result = results.NdtSingleTestResult(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 35, 123456,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 51, 45, 123456,
+                                       pytz.utc),
+            throughput=98.235)
+        result.latency = 23.8
+        result.errors = [
+            results.TestError(
+                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
+                'mock error message 1'),
+        ]
+        encoded_expected = """
+{
+    "start_time": "2016-02-26T15:51:23.452234Z",
+    "end_time": "2016-02-26T15:59:33.284345Z",
+    "client": "mock_client",
+    "client_version": "mock_client_version",
+    "os": "mock_os",
+    "os_version": "mock_os_version",
+    "c2s_start_time": "2016-02-26T15:51:24.123456Z",
+    "c2s_end_time": "2016-02-26T15:51:34.123456Z",
+    "c2s_throughput": 10.127,
+    "s2c_start_time": "2016-02-26T15:51:35.123456Z",
+    "s2c_end_time": "2016-02-26T15:51:45.123456Z",
+    "s2c_throughput": 98.235,
+    "latency": 23.8,
+    "errors": [
+        {
+            "timestamp": "2016-02-26T15:53:29.123456Z",
+            "message": "mock error message 1"
+        }
+    ]
+}"""
+
+        encoded_actual = self.encoder.encode(result)
+        self.assertJsonEqual(encoded_expected, encoded_actual)
+
+    def test_encodes_correctly_when_c2s_result_is_missing(self):
+        result = create_ndt_result(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
+                                       pytz.utc),
+            client='mock_client',
+            client_version='mock_client_version',
+            os='mock_os',
+            os_version='mock_os_version')
+        result.s2c_result = results.NdtSingleTestResult(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 35, 123456,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 51, 45, 123456,
+                                       pytz.utc),
+            throughput=98.235)
+        result.latency = 23.8
+        result.errors = [
+            results.TestError(
+                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
+                'mock error message 1'),
+        ]
+        encoded_expected = """
+{
+    "start_time": "2016-02-26T15:51:23.452234Z",
+    "end_time": "2016-02-26T15:59:33.284345Z",
+    "client": "mock_client",
+    "client_version": "mock_client_version",
+    "os": "mock_os",
+    "os_version": "mock_os_version",
+    "c2s_start_time": null,
+    "c2s_end_time": null,
+    "c2s_throughput": null,
+    "s2c_start_time": "2016-02-26T15:51:35.123456Z",
+    "s2c_end_time": "2016-02-26T15:51:45.123456Z",
+    "s2c_throughput": 98.235,
+    "latency": 23.8,
+    "errors": [
+        {
+            "timestamp": "2016-02-26T15:53:29.123456Z",
+            "message": "mock error message 1"
+        }
+    ]
+}"""
+
+        encoded_actual = self.encoder.encode(result)
+        self.assertJsonEqual(encoded_expected, encoded_actual)
+
+    def test_encodes_correctly_when_s2c_result_is_missing(self):
+        result = create_ndt_result(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
+                                       pytz.utc),
+            client='mock_client',
+            client_version='mock_client_version',
+            os='mock_os',
+            os_version='mock_os_version')
+        result.c2s_result = results.NdtSingleTestResult(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 24, 123456,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 51, 34, 123456,
+                                       pytz.utc),
+            throughput=10.127)
+        result.latency = 23.8
+        result.errors = [
+            results.TestError(
+                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
+                'mock error message 1'),
+        ]
+        encoded_expected = """
+{
+    "start_time": "2016-02-26T15:51:23.452234Z",
+    "end_time": "2016-02-26T15:59:33.284345Z",
+    "client": "mock_client",
+    "client_version": "mock_client_version",
+    "os": "mock_os",
+    "os_version": "mock_os_version",
+    "c2s_start_time": "2016-02-26T15:51:24.123456Z",
+    "c2s_end_time": "2016-02-26T15:51:34.123456Z",
+    "c2s_throughput": 10.127,
+    "s2c_start_time": null,
+    "s2c_end_time": null,
+    "s2c_throughput": null,
+    "latency": 23.8,
+    "errors": [
+        {
+            "timestamp": "2016-02-26T15:53:29.123456Z",
+            "message": "mock error message 1"
+        }
+    ]
+}"""
+
+        encoded_actual = self.encoder.encode(result)
+        self.assertJsonEqual(encoded_expected, encoded_actual)
+
+    def test_encodes_correctly_when_latency_is_missing(self):
+        result = create_ndt_result(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
+                                       pytz.utc),
+            client='mock_client',
+            client_version='mock_client_version',
+            os='mock_os',
+            os_version='mock_os_version')
+        result.c2s_result = results.NdtSingleTestResult(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 24, 123456,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 51, 34, 123456,
+                                       pytz.utc),
+            throughput=10.127)
+        result.s2c_result = results.NdtSingleTestResult(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 35, 123456,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 51, 45, 123456,
+                                       pytz.utc),
+            throughput=98.235)
+        result.errors = [
+            results.TestError(
+                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
+                'mock error message 1'),
+        ]
+        encoded_expected = """
+{
+    "start_time": "2016-02-26T15:51:23.452234Z",
+    "end_time": "2016-02-26T15:59:33.284345Z",
+    "client": "mock_client",
+    "client_version": "mock_client_version",
+    "os": "mock_os",
+    "os_version": "mock_os_version",
+    "c2s_start_time": "2016-02-26T15:51:24.123456Z",
+    "c2s_end_time": "2016-02-26T15:51:34.123456Z",
+    "c2s_throughput": 10.127,
+    "s2c_start_time": "2016-02-26T15:51:35.123456Z",
+    "s2c_end_time": "2016-02-26T15:51:45.123456Z",
+    "s2c_throughput": 98.235,
+    "latency": null,
+    "errors": [
+        {
+            "timestamp": "2016-02-26T15:53:29.123456Z",
+            "message": "mock error message 1"
+        }
+    ]
+}"""
+
+        encoded_actual = self.encoder.encode(result)
+        self.assertJsonEqual(encoded_expected, encoded_actual)
+
+    def test_encodes_zero_valued_metrics(self):
+        """Explicit zeroes should be encoded as zeroes, not nulls."""
+        result = create_ndt_result(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
+                                       pytz.utc),
+            client='mock_client',
+            client_version='mock_client_version',
+            os='mock_os',
+            os_version='mock_os_version')
+        result.c2s_result = results.NdtSingleTestResult(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 24, 123456,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 51, 34, 123456,
+                                       pytz.utc),
+            throughput=0.0)
+        result.s2c_result = results.NdtSingleTestResult(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 35, 123456,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 51, 45, 123456,
+                                       pytz.utc),
+            throughput=0.0)
+        result.latency = 0.0
+        result.errors = [
+            results.TestError(
+                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
+                'mock error message 1'),
+        ]
+        encoded_expected = """
+{
+    "start_time": "2016-02-26T15:51:23.452234Z",
+    "end_time": "2016-02-26T15:59:33.284345Z",
+    "client": "mock_client",
+    "client_version": "mock_client_version",
+    "os": "mock_os",
+    "os_version": "mock_os_version",
+    "c2s_start_time": "2016-02-26T15:51:24.123456Z",
+    "c2s_end_time": "2016-02-26T15:51:34.123456Z",
+    "c2s_throughput": 0.0,
+    "s2c_start_time": "2016-02-26T15:51:35.123456Z",
+    "s2c_end_time": "2016-02-26T15:51:45.123456Z",
+    "s2c_throughput": 0.0,
+    "latency": 0.0,
+    "errors": [
+        {
+            "timestamp": "2016-02-26T15:53:29.123456Z",
+            "message": "mock error message 1"
         }
     ]
 }"""

--- a/tests/test_result_encoder.py
+++ b/tests/test_result_encoder.py
@@ -232,11 +232,6 @@ class NdtResultEncoderTest(unittest.TestCase):
                                        pytz.utc),
             throughput=98.235)
         result.latency = 23.8
-        result.errors = [
-            results.TestError(
-                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
-                'mock error message 1'),
-        ]
         encoded_expected = """
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
@@ -252,12 +247,7 @@ class NdtResultEncoderTest(unittest.TestCase):
     "s2c_end_time": "2016-02-26T15:51:45.123456Z",
     "s2c_throughput": 98.235,
     "latency": 23.8,
-    "errors": [
-        {
-            "timestamp": "2016-02-26T15:53:29.123456Z",
-            "message": "mock error message 1"
-        }
-    ]
+    "errors": []
 }"""
 
         encoded_actual = self.encoder.encode(result)
@@ -280,11 +270,6 @@ class NdtResultEncoderTest(unittest.TestCase):
                                        pytz.utc),
             throughput=10.127)
         result.latency = 23.8
-        result.errors = [
-            results.TestError(
-                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
-                'mock error message 1'),
-        ]
         encoded_expected = """
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
@@ -300,12 +285,7 @@ class NdtResultEncoderTest(unittest.TestCase):
     "s2c_end_time": null,
     "s2c_throughput": null,
     "latency": 23.8,
-    "errors": [
-        {
-            "timestamp": "2016-02-26T15:53:29.123456Z",
-            "message": "mock error message 1"
-        }
-    ]
+    "errors": []
 }"""
 
         encoded_actual = self.encoder.encode(result)
@@ -333,11 +313,6 @@ class NdtResultEncoderTest(unittest.TestCase):
             end_time=datetime.datetime(2016, 2, 26, 15, 51, 45, 123456,
                                        pytz.utc),
             throughput=98.235)
-        result.errors = [
-            results.TestError(
-                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
-                'mock error message 1'),
-        ]
         encoded_expected = """
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
@@ -353,12 +328,7 @@ class NdtResultEncoderTest(unittest.TestCase):
     "s2c_end_time": "2016-02-26T15:51:45.123456Z",
     "s2c_throughput": 98.235,
     "latency": null,
-    "errors": [
-        {
-            "timestamp": "2016-02-26T15:53:29.123456Z",
-            "message": "mock error message 1"
-        }
-    ]
+    "errors": []
 }"""
 
         encoded_actual = self.encoder.encode(result)
@@ -388,11 +358,6 @@ class NdtResultEncoderTest(unittest.TestCase):
                                        pytz.utc),
             throughput=0.0)
         result.latency = 0.0
-        result.errors = [
-            results.TestError(
-                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
-                'mock error message 1'),
-        ]
         encoded_expected = """
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
@@ -408,12 +373,7 @@ class NdtResultEncoderTest(unittest.TestCase):
     "s2c_end_time": "2016-02-26T15:51:45.123456Z",
     "s2c_throughput": 0.0,
     "latency": 0.0,
-    "errors": [
-        {
-            "timestamp": "2016-02-26T15:53:29.123456Z",
-            "message": "mock error message 1"
-        }
-    ]
+    "errors": []
 }"""
 
         encoded_actual = self.encoder.encode(result)


### PR DESCRIPTION
Finishes the implementation of NdtResultEncoder so that it encodes all the
fields of an NdtResult object.

Fixes some small documentation errors in NdtResult's docstring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/16)
<!-- Reviewable:end -->
