### PR TITLE
Adding OS metadata wrapper

### DIFF
--- a/client_wrapper/canonicalize.py
+++ b/client_wrapper/canonicalize.py
@@ -46,19 +46,13 @@ def os_to_shortname(os, os_version):
         UnsupportedPlatformError if the caller specifies an OS and version
         combination that does not have a known shortname.
     """
-    shortname_map = {
-        #TODO(mtlynch): Check whether this is the right version string for
-        # Win10.
-        'Windows-10.0': names.WINDOWS_10,
-        'Ubuntu-14.04': names.UBUNTU_14,
-        #TODO(mtlynch): Check whether this is the right version string for
-        # El Capitan.
-        'OSX-10.11': names.OSX_10_11,
-    }
-    key = '%s-%s' % (os, os_version)
-    try:
-        return shortname_map[key]
-    except KeyError:
+    if os == 'Windows' and os_version == '10':
+        return names.WINDOWS_10
+    elif os == 'Ubuntu' and os_version == '14.04':
+        return names.UBUNTU_14
+    elif os == 'OSX' and os_version.startswith('10.11'):
+        return names.OSX_10_11
+    else:
         raise UnsupportedPlatformError('Unsupported OS platform: %s v%s' %
                                        (os, os_version))
 

--- a/client_wrapper/filename.py
+++ b/client_wrapper/filename.py
@@ -46,7 +46,7 @@ def create_result_filename(result):
                                                          result.browser_version)
     except canonicalize.Error as e:
         raise FilenameCreationError(
-            'Could not generate filename for NDT result: %s', e.message)
+            'Could not generate filename for NDT result: %s' % e.message)
     client = result.client
     timestamp = _format_time(result.start_time)
     return _FILENAME_FORMAT.format(os=os,

--- a/client_wrapper/os_metadata.py
+++ b/client_wrapper/os_metadata.py
@@ -1,0 +1,48 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import platform
+
+
+def get_os_metadata():
+    """Retrieves the OS name and version for the host system.
+
+    Retrieves the OS name and OS version string for the host system. The OS name
+    can be "Windows", "OSX", the name of the Linux distribution, or, if the OS
+    is none of those, the name will be the OS platform name. The version string
+    is the version that corresponds to the OS or distribution (not the OS
+    kernel).
+
+    Returns:
+        A two-tuple of OS name and OS version string. Examples:
+
+            ('Windows', '10')
+            ('OSX', '10.11.3')
+            ('Ubuntu', '14.04')
+    """
+    os_name = platform.system()
+    if os_name == 'Linux':
+        return _get_linux_metadata()
+    elif os_name == 'Darwin':
+        return _get_osx_metadata()
+    return os_name, platform.release()
+
+
+def _get_linux_metadata():
+    linux_distribution, distribution_version, _ = platform.linux_distribution()
+    return linux_distribution, distribution_version
+
+
+def _get_osx_metadata():
+    return 'OSX', platform.mac_ver()[0]

--- a/tests/test_canonicalize.py
+++ b/tests/test_canonicalize.py
@@ -23,11 +23,11 @@ class CanonicalizeTest(unittest.TestCase):
 
     def test_os_to_shortname_converts_recognized_platforms(self):
         self.assertEqual(names.WINDOWS_10,
-                         canonicalize.os_to_shortname('Windows', '10.0'))
+                         canonicalize.os_to_shortname('Windows', '10'))
         self.assertEqual(names.UBUNTU_14,
                          canonicalize.os_to_shortname('Ubuntu', '14.04'))
         self.assertEqual(names.OSX_10_11,
-                         canonicalize.os_to_shortname('OSX', '10.11'))
+                         canonicalize.os_to_shortname('OSX', '10.11.3'))
 
     def test_os_to_shortname_raises_error_on_unsupported_platforms(self):
         with self.assertRaises(canonicalize.UnsupportedPlatformError):

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -42,7 +42,7 @@ class FilenamesTest(unittest.TestCase):
         self.assertEqual(
             'win10-chrome49-ndt_js-2016-02-26T155423Z-results.json',
             get_result_filename(os='Windows',
-                                os_version='10.0',
+                                os_version='10',
                                 browser=names.CHROME,
                                 browser_version='49.0.2623',
                                 client=names.NDT_HTML5,
@@ -51,7 +51,7 @@ class FilenamesTest(unittest.TestCase):
         self.assertEqual(
             'osx10.11-safari9-ndt_js-2017-03-29T042116Z-results.json',
             get_result_filename(os='OSX',
-                                os_version='10.11',
+                                os_version='10.11.3',
                                 browser=names.SAFARI,
                                 browser_version='9.0.3',
                                 client=names.NDT_HTML5,

--- a/tests/test_os_metadata.py
+++ b/tests/test_os_metadata.py
@@ -1,0 +1,70 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import platform
+import unittest
+
+import mock
+
+from client_wrapper import os_metadata
+
+
+class OsMetadataTest(unittest.TestCase):
+
+    def setUp(self):
+        system_patcher = mock.patch.object(platform, 'system')
+        self.addCleanup(system_patcher.stop)
+        system_patcher.start()
+
+        release_patcher = mock.patch.object(platform, 'release')
+        self.addCleanup(release_patcher.stop)
+        release_patcher.start()
+
+        mac_ver_patcher = mock.patch.object(platform, 'mac_ver')
+        self.addCleanup(mac_ver_patcher.stop)
+        mac_ver_patcher.start()
+
+        distribution_patcher = mock.patch.object(platform, 'linux_distribution')
+        self.addCleanup(distribution_patcher.stop)
+        distribution_patcher.start()
+
+    def test_detects_osx_el_capitan(self):
+        platform.system.return_value = 'Darwin'
+        platform.mac_ver.return_value = ('10.11.3', ('', '', ''), 'i386')
+        os_name, os_version = os_metadata.get_os_metadata()
+        self.assertEqual('OSX', os_name)
+        self.assertEqual('10.11.3', os_version)
+
+    def test_detects_ubuntu_14_04(self):
+        platform.system.return_value = 'Linux'
+        platform.linux_distribution.return_value = ('Ubuntu', '14.04',
+                                                    'ignored value')
+        os_name, os_version = os_metadata.get_os_metadata()
+        self.assertEqual('Ubuntu', os_name)
+        self.assertEqual('14.04', os_version)
+
+    def test_detects_windows_10(self):
+        platform.system.return_value = 'Windows'
+        platform.release.return_value = '10'
+        os_name, os_version = os_metadata.get_os_metadata()
+        self.assertEqual('Windows', os_name)
+        self.assertEqual('10', os_version)
+
+    def test_detects_unknown_os(self):
+        platform.system.return_value = 'Imaginary OS'
+        platform.release.return_value = '54.23'
+        os_name, os_version = os_metadata.get_os_metadata()
+        self.assertEqual('Imaginary OS', os_name)
+        self.assertEqual('54.23', os_version)


### PR DESCRIPTION
Adding a module to gather OS information. This detects the OS of the host
system and returns a os, version pair.

Also fixes a few places where we had the expected OS version strings wrong
for OS X El Capitan (should be 10.11.x) and Windows 10 (should just be 10).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/19)
<!-- Reviewable:end -->
