### PR TITLE
Tying everything together to save output

### DIFF
--- a/client_wrapper/client_wrapper.py
+++ b/client_wrapper/client_wrapper.py
@@ -13,9 +13,13 @@
 # limitations under the License.
 
 import argparse
+import os
 
+import filename
 import html5_driver
 import names
+import result_encoder
+import os_metadata
 
 
 def main(args):
@@ -29,15 +33,21 @@ def main(args):
     for i in range(args.iterations):
         print 'starting iteration %d...' % (i + 1)
         result = driver.perform_test()
+        result.os, result.os_version = os_metadata.get_os_metadata()
+        print _jsonify_result(result)
+        _save_result(result, args.output)
 
-        print '\tc2s_throughput: %s Mbps' % result.c2s_result.throughput
-        print '\ts2c_throughput: %s Mbps' % result.s2c_result.throughput
-        if result.errors:
-            print '\terrors:'
-            for error in result.errors:
-                print '\t * %s: %s' % (
-                    error.timestamp.strftime('%y-%m-%d %H:%M:%S'),
-                    error.message)
+
+def _save_result(result, output_dir):
+    output_filename = filename.create_result_filename(result)
+    output_path = os.path.join(output_dir, output_filename)
+    with open(output_path, 'w') as output_file:
+        output_file.write(_jsonify_result(result))
+
+
+def _jsonify_result(result):
+    return result_encoder.NdtResultEncoder(indent=2,
+                                           sort_keys=True).encode(result)
 
 
 if __name__ == '__main__':
@@ -53,6 +63,7 @@ if __name__ == '__main__':
                         choices=('chrome', 'firefox', 'safari', 'edge'))
     parser.add_argument('--client_url',
                         help='URL of NDT client (for server-hosted clients)')
+    parser.add_argument('--output', help='Directory in which to write output')
     parser.add_argument('--iterations',
                         help='Number of iterations to run',
                         type=int,

--- a/client_wrapper/client_wrapper.py
+++ b/client_wrapper/client_wrapper.py
@@ -39,6 +39,15 @@ def main(args):
 
 
 def _save_result(result, output_dir):
+    """Saves an NdtResult instance to a file in output_dir.
+
+    Serializes an NdtResult to JSON format, automatically generates a
+    filename based on the NdtResult metadata, then saves it to output_dir.
+
+    Args:
+        result: NdtResult instance to save.
+        output_dir: Directory in which to result file.
+    """
     output_filename = filename.create_result_filename(result)
     output_path = os.path.join(output_dir, output_filename)
     with open(output_path, 'w') as output_file:

--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -48,6 +48,7 @@ class NdtHtml5SeleniumDriver(object):
             A populated NdtResult object.
         """
         result = results.NdtResult(start_time=None, end_time=None, errors=[])
+        result.client = names.NDT_HTML5
 
         with contextlib.closing(_create_browser(self._browser)) as driver:
             result.browser = self._browser


### PR DESCRIPTION
This commit ties several previous commits together to allow the user to
save NDT results to an appropriately named output file containing the results
serialized to JSON format.

Note that _jsonify_result and _save_result do *not* have unit test coverage
currently. I started to implement it, then realized we'd be mocking out like
8 interfaces to test a 4 line function and it seemed excessive, but let me
know if you think these are worth testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/21)
<!-- Reviewable:end -->
