### PR TITLE
Refactoring NDT HTML5 driver unit tests

### DIFF
--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -22,28 +22,25 @@ from selenium.common import exceptions
 from client_wrapper import html5_driver
 
 
-class NdtHtml5SeleniumDriverGeneralTest(unittest.TestCase):
+class NdtHtml5SeleniumDriverTest(unittest.TestCase):
 
     def setUp(self):
-        self.mock_browser = mock.MagicMock()
-        self.mock_browser.capabilities = {'version': 'mock_version'}
-        self.mock_driver = mock.patch.object(html5_driver.webdriver,
-                                             'Firefox',
-                                             autospec=True,
-                                             return_value=self.mock_browser)
-        self.addCleanup(self.mock_driver.stop)
-        self.mock_driver.start()
-
         self.mock_visibility = mock.patch.object(selenium_expected_conditions,
                                                  'visibility_of',
                                                  autospec=True)
         self.addCleanup(self.mock_visibility.stop)
         self.mock_visibility.start()
-        self.mock_visibility.return_value = True
+
+        self.mock_driver = mock.Mock()
+        self.mock_driver.capabilities = {'version': 'mock_version'}
+        firefox_patcher = mock.patch.object(html5_driver.webdriver, 'Firefox')
+        self.addCleanup(firefox_patcher.stop)
+        firefox_patcher.start()
 
     def test_invalid_URL_throws_error(self):
-        self.mock_browser.get.side_effect = exceptions.WebDriverException(
-            u'Failed to load test UI.')
+        self.mock_driver.get.side_effect = (
+            exceptions.WebDriverException('Failed to load test UI.'))
+        html5_driver.webdriver.Firefox.return_value = self.mock_driver
 
         test_results = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
@@ -83,52 +80,25 @@ class NdtHtml5SeleniumDriverGeneralTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             selenium_driver.perform_test()
 
-
-class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
-
-    def setUp(self):
-        self.mock_visibility = mock.patch.object(selenium_expected_conditions,
-                                                 'visibility_of',
-                                                 autospec=True)
-        self.addCleanup(self.mock_visibility.stop)
-        self.mock_visibility.return_value = True
-        self.mock_visibility.start()
-
     def test_results_page_displays_non_numeric_latency(self):
+        mock_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='34'),
+            'upload-speed-units': mock.Mock(text='kb/s'),
+            'download-speed': mock.Mock(text='34'),
+            'download-speed-units': mock.Mock(text='Mb/s'),
+            'latency': mock.Mock(text='Non-numeric value'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_elements[id])
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        html5_driver.webdriver.Firefox.return_value = self.mock_driver
 
-        class NewDriver(object):
-
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_element_by_id(self, id):
-                if id == 'upload-speed-units':
-                    return mock.Mock(text='kb/s', autospec=True)
-                elif id == 'download-speed-units':
-                    return mock.Mock(text='Mb/s', autospec=True)
-                elif id == 'latency':
-                    return mock.Mock(text='Non-numeric value', autospec=True)
-                else:
-                    return mock.Mock(text='34', autospec=True)
-
-            def find_elements_by_xpath(self, xpath):
-                return [mock.Mock(autospec=True)]
-
-        with mock.patch.object(html5_driver.webdriver,
-                               'Firefox',
-                               autospec=True,
-                               return_value=NewDriver()):
-
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
-                browser='firefox',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1000).perform_test()
+        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
 
         # And the appropriate error object is contained in the list
         self.assertEqual(len(test_results.errors), 1)
@@ -136,40 +106,24 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
                          'illegal value shown for latency: Non-numeric value')
 
     def test_results_page_displays_non_numeric_c2s_throughput(self):
+        mock_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='Non-numeric value'),
+            'upload-speed-units': mock.Mock(text='kb/s'),
+            'download-speed': mock.Mock(text='34'),
+            'download-speed-units': mock.Mock(text='Mb/s'),
+            'latency': mock.Mock(text='34'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_elements[id])
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        html5_driver.webdriver.Firefox.return_value = self.mock_driver
 
-        class NewDriver(object):
-
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_element_by_id(self, id):
-                if id == 'upload-speed-units':
-                    return mock.Mock(text='kb/s', autospec=True)
-                elif id == 'download-speed-units':
-                    return mock.Mock(text='Mb/s', autospec=True)
-                elif id == 'upload-speed':
-                    return mock.Mock(text='Non-numeric value', autospec=True)
-                else:
-                    return mock.Mock(text='34', autospec=True)
-
-            def find_elements_by_xpath(self, xpath):
-                return [mock.Mock(autospec=True)]
-
-        with mock.patch.object(html5_driver.webdriver,
-                               'Firefox',
-                               autospec=True,
-                               return_value=NewDriver()):
-
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
-                browser='firefox',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1000).perform_test()
+        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
 
         # And only the appropriate error object is contained in the list
         self.assertEqual(len(test_results.errors), 1)
@@ -178,40 +132,24 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
             'illegal value shown for c2s throughput: Non-numeric value')
 
     def test_results_page_displays_non_numeric_s2c_throughput(self):
+        mock_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='34'),
+            'upload-speed-units': mock.Mock(text='kb/s'),
+            'download-speed': mock.Mock(text='Non-numeric value'),
+            'download-speed-units': mock.Mock(text='Mb/s'),
+            'latency': mock.Mock(text='34'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_elements[id])
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        html5_driver.webdriver.Firefox.return_value = self.mock_driver
 
-        class NewDriver(object):
-
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_element_by_id(self, id):
-                if id == 'upload-speed-units':
-                    return mock.Mock(text='kb/s', autospec=True)
-                elif id == 'download-speed-units':
-                    return mock.Mock(text='Mb/s', autospec=True)
-                elif id == 'download-speed':
-                    return mock.Mock(text='Non-numeric value', autospec=True)
-                else:
-                    return mock.Mock(text='34', autospec=True)
-
-            def find_elements_by_xpath(self, xpath):
-                return [mock.Mock(autospec=True)]
-
-        with mock.patch.object(html5_driver.webdriver,
-                               'Firefox',
-                               autospec=True,
-                               return_value=NewDriver()):
-
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
-                browser='firefox',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1000).perform_test()
+        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
 
         # And only the appropriate error object is contained in the list
         self.assertEqual(len(test_results.errors), 1)
@@ -226,90 +164,59 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
         corresponding error objects are added to the errors list that indicate
         that each of these values is invalid.
         """
-
         # We patch selenium's web driver so it always has a non numeric
         # value as a WebElement.text attribute
-        class NewWebElement(object):
+        mock_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='Non-numeric value'),
+            'upload-speed-units': mock.Mock(text='kb/s'),
+            'download-speed': mock.Mock(text='Non-numeric value'),
+            'download-speed-units': mock.Mock(text='Mb/s'),
+            'latency': mock.Mock(text='Non-numeric value'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_elements[id])
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        html5_driver.webdriver.Firefox.return_value = self.mock_driver
 
-            def __init__(self):
-                self.text = 'Non numeric value'
-
-            def click(self):
-                pass
-
-        class NewDriver(object):
-
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_element_by_id(self, id):
-                return NewWebElement()
-
-            def find_elements_by_xpath(self, xpath):
-                return [NewWebElement()]
-
-        with mock.patch.object(html5_driver.webdriver,
-                               'Firefox',
-                               autospec=True,
-                               return_value=NewDriver()):
-
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
-                browser='firefox',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1000).perform_test()
+        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
 
         # And the appropriate error objects are contained in
         # the list
         self.assertEqual(
             test_results.errors[0].message,
-            'illegal value shown for c2s throughput: Non numeric value')
+            'illegal value shown for c2s throughput: Non-numeric value')
         self.assertEqual(
             test_results.errors[1].message,
-            'illegal value shown for s2c throughput: Non numeric value')
+            'illegal value shown for s2c throughput: Non-numeric value')
         self.assertEqual(test_results.errors[2].message,
-                         'illegal value shown for latency: Non numeric value')
+                         'illegal value shown for latency: Non-numeric value')
 
     def test_results_page_displays_numeric_latency(self):
         """A valid (numeric) latency results in an empty errors list."""
-
         # Mock so always returns a numeric value for a WebElement.text attribute
+        mock_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='72'),
+            'upload-speed-units': mock.Mock(text='Mb/s'),
+            'download-speed': mock.Mock(text='72'),
+            'download-speed-units': mock.Mock(text='Mb/s'),
+            'latency': mock.Mock(text='72'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_elements[id])
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        html5_driver.webdriver.Firefox.return_value = self.mock_driver
 
-        class NewDriver(object):
-
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_element_by_id(self, id):
-                if id == 'download-speed-units':
-                    return mock.Mock(text='Mb/s', autospec=True)
-                elif id == 'upload-speed-units':
-                    return mock.Mock(text='Mb/s', autospec=True)
-                return mock.Mock(text='72', autospec=True)
-
-            def find_elements_by_xpath(self, xpath):
-                return [mock.Mock(autospec=True)]
-
-        with mock.patch.object(html5_driver.webdriver,
-                               'Firefox',
-                               autospec=True,
-                               return_value=NewDriver()):
-
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
-                browser='firefox',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1000).perform_test()
+        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
 
         self.assertEqual(test_results.latency, 72.0)
         # And an error object is not contained in the list
@@ -317,42 +224,25 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
 
     def test_s2c_gbps_speed_conversion(self):
         """Test s2c speed converts from Gb/s to Mb/s correctly."""
-
         # If s2c speed is 72 Gb/s and c2s is speed is 34 in the browser
+        mock_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='34'),
+            'upload-speed-units': mock.Mock(text='Mb/s'),
+            'download-speed': mock.Mock(text='72'),
+            'download-speed-units': mock.Mock(text='Gb/s'),
+            'latency': mock.Mock(text='34'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_elements[id])
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        html5_driver.webdriver.Firefox.return_value = self.mock_driver
 
-        class NewDriver(object):
-
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_element_by_id(self, id):
-                if id == 'download-speed-units':
-                    return mock.Mock(text='Gb/s', autospec=True)
-                elif id == 'download-speed':
-                    return mock.Mock(text='72', autospec=True)
-                elif id == 'upload-speed-units':
-                    return mock.Mock(text='Mb/s', autospec=True)
-                else:
-                    return mock.Mock(text='34', autospec=True)
-
-            def find_elements_by_xpath(self, xpath):
-                return [mock.Mock(autospec=True)]
-
-        with mock.patch.object(html5_driver.webdriver,
-                               'Firefox',
-                               autospec=True,
-                               return_value=NewDriver()):
-
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
-                browser='firefox',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1000).perform_test()
+        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
 
         # Then s2c is converted from Gb/s to Mb/s
         self.assertEqual(test_results.s2c_result.throughput, 72000)
@@ -362,117 +252,78 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
         self.assertEqual(len(test_results.errors), 0)
 
     def test_invalid_throughput_unit_raises_error(self):
+        mock_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='34'),
+            'upload-speed-units': mock.Mock(text='not a unit'),
+            'download-speed': mock.Mock(text='72'),
+            'download-speed-units': mock.Mock(text='Gb/s'),
+            'latency': mock.Mock(text='34'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_elements[id])
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        html5_driver.webdriver.Firefox.return_value = self.mock_driver
 
-        class NewDriver(object):
-
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_element_by_id(self, id):
-                if id == 'download-speed-units':
-                    return mock.Mock(text='Gb/s', autospec=True)
-                elif id == 'download-speed':
-                    return mock.Mock(text='72', autospec=True)
-                elif id == 'upload-speed-units':
-                    return mock.Mock(text='not a unit', autospec=True)
-                else:
-                    return mock.Mock(text='34', autospec=True)
-
-            def find_elements_by_xpath(self, xpath):
-                return [mock.Mock(autospec=True)]
-
-        with mock.patch.object(html5_driver.webdriver,
-                               'Firefox',
-                               autospec=True,
-                               return_value=NewDriver()):
-
-            # And a value error is raised because the c2s throughput
-            # unit was invalid.
-            with self.assertRaises(ValueError):
-                html5_driver.NdtHtml5SeleniumDriver(
-                    browser='firefox',
-                    url='http://ndt.mock-server.com:7123/',
-                    timeout=1000).perform_test()
-
-    def test_reading_in_result_page_timeout_throws_error(self):
-
-        # If a timeout exception occurs when the driver attempts to
-        # read the metric page
-        class NewDriver(object):
-
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_element_by_id(self, id):
-                if id == 'upload-speed':
-                    raise exceptions.TimeoutException
-                else:
-                    return mock.Mock(text='34', autospec=True)
-
-            def find_elements_by_xpath(self, xpath):
-                return [mock.Mock(autospec=True)]
-
-        with mock.patch.object(html5_driver.webdriver,
-                               'Firefox',
-                               autospec=True,
-                               return_value=NewDriver()):
-
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
+        # And a value error is raised because the c2s throughput unit was
+        # invalid.
+        with self.assertRaises(ValueError):
+            html5_driver.NdtHtml5SeleniumDriver(
                 browser='firefox',
                 url='http://ndt.mock-server.com:7123/',
                 timeout=1000).perform_test()
+
+    def test_reading_in_result_page_timeout_throws_error(self):
+        # Simulate a timeout exception when the driver attempts to read the
+        # metric page.
+        def mock_find_element_by_id(id):
+            if id == 'upload-speed':
+                raise exceptions.TimeoutException
+            mock_elements = {
+                'websocketButton': mock.Mock(),
+                'upload-speed-units': mock.Mock(text='Mb/s'),
+                'download-speed': mock.Mock(text='72'),
+                'download-speed-units': mock.Mock(text='Mb/s'),
+                'latency': mock.Mock(text='72'),
+                'results': mock.Mock(),
+            }
+            return mock_elements[id]
+
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_find_element_by_id(id))
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        html5_driver.webdriver.Firefox.return_value = self.mock_driver
+
+        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
 
         # The appropriate error object is contained in the list.
         self.assertEqual(test_results.errors[0].message,
                          'Test did not complete within timeout period.')
 
-    def test_chrome_driver_can_be_used_for_test(self):
+    @mock.patch.object(html5_driver.webdriver, 'Chrome')
+    def test_chrome_driver_can_be_used_for_test(self, mock_chrome):
+        mock_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='34'),
+            'upload-speed-units': mock.Mock(text='Mb/s'),
+            'download-speed': mock.Mock(text='72'),
+            'download-speed-units': mock.Mock(text='Gb/s'),
+            'latency': mock.Mock(text='34'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_elements[id])
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        mock_chrome.return_value = self.mock_driver
 
-        class NewDriver(object):
-
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_elements_by_xpath(self, xpath):
-                return [mock.Mock(autospec=True)]
-
-            def find_element_by_id(self, id):
-                if id == 'download-speed-units':
-                    return mock.Mock(text='Gb/s', autospec=True)
-                elif id == 'download-speed':
-                    return mock.Mock(text='72', autospec=True)
-                elif id == 'upload-speed-units':
-                    return mock.Mock(text='Mb/s', autospec=True)
-                else:
-                    return mock.Mock(text='34', autospec=True)
-
-        with mock.patch.object(html5_driver.webdriver,
-                               'Chrome',
-                               autospec=True,
-                               return_value=NewDriver()):
-
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
-                browser='chrome',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1000).perform_test()
+        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            browser='chrome',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
 
         # Then s2c is converted from Gb/s to Mb/s
         self.assertEqual(test_results.s2c_result.throughput, 72000)
@@ -481,41 +332,26 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
         # And an error object is not contained in the list
         self.assertEqual(len(test_results.errors), 0)
 
-    def test_edge_driver_can_be_used_for_test(self):
+    @mock.patch.object(html5_driver.webdriver, 'Edge')
+    def test_edge_driver_can_be_used_for_test(self, mock_edge):
+        mock_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='34'),
+            'upload-speed-units': mock.Mock(text='Mb/s'),
+            'download-speed': mock.Mock(text='72'),
+            'download-speed-units': mock.Mock(text='Gb/s'),
+            'latency': mock.Mock(text='34'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_elements[id])
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        mock_edge.return_value = self.mock_driver
 
-        class NewDriver(object):
-
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_elements_by_xpath(self, xpath):
-                return [mock.Mock(autospec=True)]
-
-            def find_element_by_id(self, id):
-                if id == 'download-speed-units':
-                    return mock.Mock(text='Gb/s', autospec=True)
-                elif id == 'download-speed':
-                    return mock.Mock(text='72', autospec=True)
-                elif id == 'upload-speed-units':
-                    return mock.Mock(text='Mb/s', autospec=True)
-                else:
-                    return mock.Mock(text='34', autospec=True)
-
-        with mock.patch.object(html5_driver.webdriver,
-                               'Edge',
-                               autospec=True,
-                               return_value=NewDriver()):
-
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
-                browser='edge',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1000).perform_test()
+        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            browser='edge',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
 
         # Then s2c is converted from Gb/s to Mb/s
         self.assertEqual(test_results.s2c_result.throughput, 72000)
@@ -524,41 +360,26 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
         # And an error object is not contained in the list
         self.assertEqual(len(test_results.errors), 0)
 
-    def test_safari_driver_can_be_used_for_test(self):
+    @mock.patch.object(html5_driver.webdriver, 'Safari')
+    def test_safari_driver_can_be_used_for_test(self, mock_safari):
+        mock_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='34'),
+            'upload-speed-units': mock.Mock(text='Mb/s'),
+            'download-speed': mock.Mock(text='72'),
+            'download-speed-units': mock.Mock(text='Gb/s'),
+            'latency': mock.Mock(text='34'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_elements[id])
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        mock_safari.return_value = self.mock_driver
 
-        class NewDriver(object):
-
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_elements_by_xpath(self, xpath):
-                return [mock.Mock(autospec=True)]
-
-            def find_element_by_id(self, id):
-                if id == 'download-speed-units':
-                    return mock.Mock(text='Gb/s', autospec=True)
-                elif id == 'download-speed':
-                    return mock.Mock(text='72', autospec=True)
-                elif id == 'upload-speed-units':
-                    return mock.Mock(text='Mb/s', autospec=True)
-                else:
-                    return mock.Mock(text='34', autospec=True)
-
-        with mock.patch.object(html5_driver.webdriver,
-                               'Safari',
-                               autospec=True,
-                               return_value=NewDriver()):
-
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
-                browser='safari',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1000).perform_test()
+        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            browser='safari',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
 
         # Then s2c is converted from Gb/s to Mb/s
         self.assertEqual(test_results.s2c_result.throughput, 72000)
@@ -569,42 +390,25 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
 
     def test_c2s_kbps_speed_conversion(self):
         """Test c2s speed converts from kb/s to Mb/s correctly."""
-
         # If c2s speed is 72 kb/s and s2c speed is 34 in the browser
+        mock_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='72'),
+            'upload-speed-units': mock.Mock(text='kb/s'),
+            'download-speed': mock.Mock(text='34'),
+            'download-speed-units': mock.Mock(text='Mb/s'),
+            'latency': mock.Mock(text='34'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_elements[id])
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        html5_driver.webdriver.Firefox.return_value = self.mock_driver
 
-        class NewDriver(object):
-
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_element_by_id(self, id):
-                if id == 'upload-speed-units':
-                    return mock.Mock(text='kb/s', autospec=True)
-                elif id == 'upload-speed':
-                    return mock.Mock(text='72', autospec=True)
-                elif id == 'download-speed-units':
-                    return mock.Mock(text='Mb/s', autospec=True)
-                else:
-                    return mock.Mock(text='34', autospec=True)
-
-            def find_elements_by_xpath(self, xpath):
-                return [mock.Mock(autospec=True)]
-
-        with mock.patch.object(html5_driver.webdriver,
-                               'Firefox',
-                               autospec=True,
-                               return_value=NewDriver()):
-
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
-                browser='firefox',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1000).perform_test()
+        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
 
         # Then c2s is converted from kb/s to Mb/s
         self.assertEqual(test_results.c2s_result.throughput, 0.072)
@@ -615,42 +419,27 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
 
     @freezegun.freeze_time('2016-01-01', tz_offset=0)
     def test_ndt_test_results_records_todays_times(self):
+        mock_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='72'),
+            'upload-speed-units': mock.Mock(text='kb/s'),
+            'download-speed': mock.Mock(text='72'),
+            'download-speed-units': mock.Mock(text='Mb/s'),
+            'latency': mock.Mock(text='72'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_elements[id])
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        html5_driver.webdriver.Firefox.return_value = self.mock_driver
 
-        class NewDriver(object):
-
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_element_by_id(self, id):
-                if id == 'upload-speed-units':
-                    return mock.Mock(text='kb/s', autospec=True)
-                elif id == 'download-speed-units':
-                    return mock.Mock(text='Mb/s', autospec=True)
-                elif id == 'upload-speed' or 'download-speed':
-                    return mock.Mock(text='72', autospec=True)
-                else:
-                    return mock.Mock(autospec=True)
-
-            def find_elements_by_xpath(self, xpath):
-                return [mock.Mock(autospec=True)]
         # When we patch datetime so it shows our current date as 2016-01-01
         self.assertEqual(datetime.datetime.now(), datetime.datetime(2016, 1, 1))
 
-        with mock.patch.object(html5_driver.webdriver,
-                               'Firefox',
-                               autospec=True,
-                               return_value=NewDriver()):
-
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
-                browser='firefox',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1000).perform_test()
+        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
 
         # Then the readings for our test start and end times occur within
         # today's date
@@ -666,41 +455,26 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
                                            tzinfo=pytz.utc))
 
     def test_ndt_test_results_increments_time_correctly(self):
-        # Create a list of times every minute starting at 2016-1-1 8:00:00
-        # and ending at 2016-1-1 8:04:00. These will be the values that our
-        # mock datetime.now() function returns.
+        # Create a list of times every minute starting at 2016-1-1 8:00:00 and
+        # ending at 2016-1-1 8:04:00. These will be the values that our mock
+        # datetime.now() function returns.
         base_date = datetime.datetime(2016, 1, 1, 8, 0, 0, tzinfo=pytz.utc)
         dates = [base_date + datetime.timedelta(0, 60) * x for x in range(6)]
 
-        class NewDriver(object):
+        mock_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='72'),
+            'upload-speed-units': mock.Mock(text='kb/s'),
+            'download-speed': mock.Mock(text='72'),
+            'download-speed-units': mock.Mock(text='Mb/s'),
+            'latency': mock.Mock(text='72'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: mock_elements[id])
+        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
+        html5_driver.webdriver.Firefox.return_value = self.mock_driver
 
-            def __init__(self):
-                self.capabilities = {'version': 'mock_version'}
-
-            def get(self, url):
-                pass
-
-            def close(self):
-                pass
-
-            def find_element_by_id(self, id):
-                if id == 'upload-speed-units':
-                    return mock.Mock(text='kb/s', autospec=True)
-                elif id == 'upload-speed':
-                    return mock.Mock(text='72', autospec=True)
-                elif id == 'download-speed-units':
-                    return mock.Mock(text='Mb/s', autospec=True)
-                else:
-                    return mock.Mock(text='34', autospec=True)
-
-            def find_elements_by_xpath(self, xpath):
-                return [mock.Mock(autospec=True)]
-
-        mock_driver = mock.patch.object(html5_driver.webdriver,
-                                        'Firefox',
-                                        autospec=True,
-                                        return_value=NewDriver())
-        mock_driver.start()
         with mock.patch.object(html5_driver.datetime,
                                'datetime',
                                autospec=True) as mocked_datetime:
@@ -710,42 +484,24 @@ class NdtHtml5SeleniumDriverCustomClassTest(unittest.TestCase):
                 browser='firefox',
                 url='http://ndt.mock-server.com:7123/',
                 timeout=1).perform_test()
-        mock_driver.stop()
 
         # And the sequence of returned values follows the expected timeline
         # that the readings are taken in.
-        self.assertEqual(test_results.start_time,
-                         datetime.datetime(2016,
-                                           1,
-                                           1,
-                                           8,
-                                           0,
-                                           0,
-                                           tzinfo=pytz.utc))
-        self.assertEqual(test_results.c2s_result.start_time,
-                         datetime.datetime(2016,
-                                           1,
-                                           1,
-                                           8,
-                                           1,
-                                           0,
-                                           tzinfo=pytz.utc))
-        self.assertEqual(test_results.s2c_result.start_time,
-                         datetime.datetime(2016,
-                                           1,
-                                           1,
-                                           8,
-                                           3,
-                                           0,
-                                           tzinfo=pytz.utc))
-        self.assertEqual(test_results.end_time,
-                         datetime.datetime(2016,
-                                           1,
-                                           1,
-                                           8,
-                                           5,
-                                           0,
-                                           tzinfo=pytz.utc))
+
+        # yapf: disable
+        self.assertEqual(
+            test_results.start_time,
+            datetime.datetime(2016, 1, 1, 8, 0, 0, tzinfo=pytz.utc))
+        self.assertEqual(
+            test_results.c2s_result.start_time,
+            datetime.datetime(2016, 1, 1, 8, 1, 0, tzinfo=pytz.utc))
+        self.assertEqual(
+            test_results.s2c_result.start_time,
+            datetime.datetime(2016, 1, 1, 8, 3, 0, tzinfo=pytz.utc))
+        self.assertEqual(
+            test_results.end_time,
+            datetime.datetime(2016, 1, 1, 8, 5, 0, tzinfo=pytz.utc))
+        # yapf: enable
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Refactoring mainly to get rid of custom-defined mock objects and replace them with uses
of the Mock library.

This should *not* introduce any significant changes in functionality. There are *some*
changes in functionality, including removing instances of autospec=True when there was
nothing to autospec and deleting mock behavior that was not relevant to the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/22)
<!-- Reviewable:end -->
