### PR TITLE
Tidying up TestError semantics

### DIFF
--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -104,9 +104,7 @@ def _load_url(driver, url, result):
     try:
         driver.get(url)
     except exceptions.WebDriverException:
-        message = 'Failed to load test UI.'
-        result.errors.append(results.TestError(
-            datetime.datetime.now(pytz.utc), message))
+        result.errors.append(results.TestError('Failed to load test UI.'))
         return False
     return True
 
@@ -172,9 +170,8 @@ def _record_test_in_progress_values(result, driver, timeout):
                                                               driver,
                                                               timeout=timeout)
     except exceptions.TimeoutException:
-        message = 'Test did not complete within timeout period.'
         result.errors.append(results.TestError(
-            datetime.datetime.now(pytz.utc), message))
+            'Test did not complete within timeout period.'))
         return False
     return True
 
@@ -239,9 +236,8 @@ def _populate_metric_values(result, driver):
         result.latency = _validate_metric(result.errors, result.latency,
                                           'latency')
     except exceptions.TimeoutException:
-        message = 'Test did not complete within timeout period.'
         result.errors.append(results.TestError(
-            datetime.datetime.now(pytz.utc), message))
+            'Test did not complete within timeout period.'))
         return False
     return True
 
@@ -300,9 +296,8 @@ def _convert_metric_to_float(errors, metric, metric_name):
     try:
         float(metric)
     except ValueError:
-        message = 'illegal value shown for ' + metric_name + ': ' + str(metric)
-        errors.append(results.TestError(
-            datetime.datetime.now(pytz.utc), message))
+        errors.append(results.TestError('illegal value shown for %s: %s' % (
+            metric_name, metric)))
         return False
     return True
 

--- a/client_wrapper/results.py
+++ b/client_wrapper/results.py
@@ -38,7 +38,7 @@ class TestError(object):
     """Log message of an error encountered in the test.
 
     Attributes:
-        message: String message describing the error.
+        message: String describing the error.
         timestamp: Datetime of when the error was observed.
     """
 

--- a/client_wrapper/results.py
+++ b/client_wrapper/results.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+
+import pytz
+
 
 class NdtSingleTestResult(object):
     """Result of a single NDT test.
@@ -34,13 +38,21 @@ class TestError(object):
     """Log message of an error encountered in the test.
 
     Attributes:
-        timestamp: Datetime of when the error was observed
         message: String message describing the error.
+        timestamp: Datetime of when the error was observed.
     """
 
-    def __init__(self, timestamp, message):
-        self.timestamp = timestamp
-        self.message = message
+    def __init__(self, message, timestamp=datetime.datetime.now(pytz.utc)):
+        self._message = message
+        self._timestamp = timestamp
+
+    @property
+    def message(self):
+        return self._message
+
+    @property
+    def timestamp(self):
+        return self._timestamp
 
 
 class NdtResult(object):

--- a/tests/test_result_encoder.py
+++ b/tests/test_result_encoder.py
@@ -87,8 +87,8 @@ class NdtResultEncoderTest(unittest.TestCase):
             os='mock_os',
             os_version='mock_os_version')
         result.errors = [results.TestError(
-            datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
-            'mock error message 1')]
+            'mock error message 1',
+            datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc))]
         encoded_expected = """
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
@@ -129,11 +129,11 @@ class NdtResultEncoderTest(unittest.TestCase):
             os_version='mock_os_version')
         result.errors = [
             results.TestError(
-                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
-                'mock error message 1'),
+                'mock error message 1',
+                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc)),
             results.TestError(
-                datetime.datetime(2016, 2, 26, 15, 53, 29, 654321, pytz.utc),
-                'mock error message 2')
+                'mock error message 2',
+                datetime.datetime(2016, 2, 26, 15, 53, 29, 654321, pytz.utc))
         ]
         encoded_expected = """
 {
@@ -194,8 +194,8 @@ class NdtResultEncoderTest(unittest.TestCase):
         result.browser_version = 'mock_browser_version'
         result.errors = [
             results.TestError(
-                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc),
-                'mock error message 1'),
+                'mock error message 1',
+                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc))
         ]
         encoded_expected = """
 {


### PR DESCRIPTION
This cleans up TestError semantics so it's a bit easier to for clients to
construct a TestError in the common case, which is to assign the timestamp
to the current UTC time. Updating unit tests to match.

Also makes TestError's fields read-only via property decorators.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/23)
<!-- Reviewable:end -->
