### PR TITLE
Adding support for Windows Server 2012 R2

### DIFF
--- a/client_wrapper/canonicalize.py
+++ b/client_wrapper/canonicalize.py
@@ -48,6 +48,8 @@ def os_to_shortname(os, os_version):
     """
     if os == 'Windows' and os_version == '10':
         return names.WINDOWS_10
+    if os == 'Windows' and os_version == '2012ServerR2':
+        return names.WINDOWS_SERVER_2012_R2
     elif os == 'Ubuntu' and os_version == '14.04':
         return names.UBUNTU_14
     elif os == 'OSX' and os_version.startswith('10.11'):

--- a/client_wrapper/names.py
+++ b/client_wrapper/names.py
@@ -28,5 +28,6 @@ SAFARI = 'safari'
 
 # OS shortnames
 WINDOWS_10 = 'win10'
+WINDOWS_SERVER_2012_R2 = 'win2012R2'
 UBUNTU_14 = 'ubuntu14.04'
 OSX_10_11 = 'osx10.11'

--- a/tests/test_filename.py
+++ b/tests/test_filename.py
@@ -49,6 +49,15 @@ class FilenamesTest(unittest.TestCase):
                                 start_time=datetime.datetime(
                                     2016, 2, 26, 15, 54, 23, 0, pytz.utc)))
         self.assertEqual(
+            'win2012R2-chrome49-ndt_js-2016-02-26T155423Z-results.json',
+            get_result_filename(os='Windows',
+                                os_version='2012ServerR2',
+                                browser=names.CHROME,
+                                browser_version='49.0.2623',
+                                client=names.NDT_HTML5,
+                                start_time=datetime.datetime(
+                                    2016, 2, 26, 15, 54, 23, 0, pytz.utc)))
+        self.assertEqual(
             'osx10.11-safari9-ndt_js-2017-03-29T042116Z-results.json',
             get_result_filename(os='OSX',
                                 os_version='10.11.3',


### PR DESCRIPTION
This adds support for saving results from a Windows Server 2012 R2 system. It initially was
not a supported platform, but supporting it facilitates testing because Win10 is not
not available in GCE, whereas Server 2012 R2 is, so this lets us test on GCE as well as
our testbed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/24)
<!-- Reviewable:end -->
