### PR TITLE
Refactoring unit tests for HTML5 driver

### DIFF
--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import
-import unittest
 import datetime
+import re
+import unittest
+
 import mock
 import pytz
 import freezegun
 import selenium.webdriver.support.expected_conditions as selenium_expected_conditions
 from selenium.common import exceptions
+
 from client_wrapper import html5_driver
 
 
@@ -33,26 +36,72 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
 
         self.mock_driver = mock.Mock()
         self.mock_driver.capabilities = {'version': 'mock_version'}
+
+        # Create mock DOM elements that are returned by calls to
+        # find_element_by_id.
+        self.mock_page_elements = {
+            'websocketButton': mock.Mock(),
+            'upload-speed': mock.Mock(text='1'),
+            'upload-speed-units': mock.Mock(text='Mb/s'),
+            'download-speed': mock.Mock(text='2'),
+            'download-speed-units': mock.Mock(text='Mb/s'),
+            'latency': mock.Mock(text='3'),
+            'results': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: self.mock_page_elements[id])
+
+        # Create mock DOM elements that are returned by calls to
+        # find_elements_by_xpath.
+        self.mock_elements_by_text = {
+            'Start Test': mock.Mock(),
+            'your upload speed': mock.Mock(),
+            'your download speed': mock.Mock(),
+        }
+
+        def mock_find_elements_by_xpath(xpath):
+            """Mock implementation that only supports searching by text."""
+            matching_text = re.match('^//\*\[contains\(text\(\), \'(.+)\'\)\]$',
+                                     xpath).group(1)
+            return [self.mock_elements_by_text[matching_text]]
+
+        self.mock_driver.find_elements_by_xpath = mock_find_elements_by_xpath
+
         firefox_patcher = mock.patch.object(html5_driver.webdriver, 'Firefox')
         self.addCleanup(firefox_patcher.stop)
         firefox_patcher.start()
 
+        html5_driver.webdriver.Firefox.return_value = self.mock_driver
+
+    def assertErrorMessagesEqual(self, expected_messages, actual_errors):
+        """Verifies that a list of TestErrors have the expected error messages.
+
+        Note that this compares just by message text and ignores timestamp.
+        """
+        actual_messages = [e.message for e in actual_errors]
+        self.assertListEqual(expected_messages, actual_messages)
+
+    def test_test_yields_valid_results_when_all_page_elements_are_expected_values(
+            self):
+        result = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
+
+        self.assertEqual(1.0, result.c2s_result.throughput)
+        self.assertEqual(2.0, result.s2c_result.throughput)
+        self.assertEqual(3.0, result.latency)
+        self.assertErrorMessagesEqual([], result.errors)
+
     def test_invalid_URL_throws_error(self):
         self.mock_driver.get.side_effect = (
             exceptions.WebDriverException('Failed to load test UI.'))
-        html5_driver.webdriver.Firefox.return_value = self.mock_driver
+        result = html5_driver.NdtHtml5SeleniumDriver(browser='firefox',
+                                                     url='invalid_url',
+                                                     timeout=1).perform_test()
 
-        test_results = html5_driver.NdtHtml5SeleniumDriver(
-            browser='firefox',
-            url='invalid_url',
-            timeout=1).perform_test()
-
-        # We have one error
-        self.assertEqual(len(test_results.errors), 1)
-
-        # And that error is about test UI loading failure
-        self.assertEqual(test_results.errors[0].message,
-                         'Failed to load test UI.')
+        self.assertErrorMessagesEqual(
+            ['Failed to load test UI.'], result.errors)
 
     def test_test_in_progress_timeout_throws_error(self):
         # Call to webdriverwait throws timeout exception
@@ -60,17 +109,13 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
                                'WebDriverWait',
                                side_effect=exceptions.TimeoutException,
                                autospec=True):
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
+            result = html5_driver.NdtHtml5SeleniumDriver(
                 browser='firefox',
                 url='http://ndt.mock-server.com:7123/',
                 timeout=1).perform_test()
 
-        # We have one error
-        self.assertEqual(len(test_results.errors), 1)
-
-        # And that is a timout error
-        self.assertEqual(test_results.errors[0].message,
-                         'Test did not complete within timeout period.')
+        self.assertErrorMessagesEqual(
+            ['Test did not complete within timeout period.'], result.errors)
 
     def test_unrecognized_browser_raises_error(self):
         selenium_driver = html5_driver.NdtHtml5SeleniumDriver(
@@ -81,81 +126,48 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
             selenium_driver.perform_test()
 
     def test_results_page_displays_non_numeric_latency(self):
-        mock_elements = {
-            'websocketButton': mock.Mock(),
-            'upload-speed': mock.Mock(text='34'),
-            'upload-speed-units': mock.Mock(text='kb/s'),
-            'download-speed': mock.Mock(text='34'),
-            'download-speed-units': mock.Mock(text='Mb/s'),
-            'latency': mock.Mock(text='Non-numeric value'),
-            'results': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_elements[id])
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
-        html5_driver.webdriver.Firefox.return_value = self.mock_driver
-
-        test_results = html5_driver.NdtHtml5SeleniumDriver(
+        self.mock_page_elements['latency'] = mock.Mock(text='Non-numeric value')
+        result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
             url='http://ndt.mock-server.com:7123/',
             timeout=1000).perform_test()
 
-        # And the appropriate error object is contained in the list
-        self.assertEqual(len(test_results.errors), 1)
-        self.assertEqual(test_results.errors[0].message,
-                         'illegal value shown for latency: Non-numeric value')
+        self.assertEqual(1.0, result.c2s_result.throughput)
+        self.assertEqual(2.0, result.s2c_result.throughput)
+        self.assertIsNone(result.latency)
+        self.assertErrorMessagesEqual(
+            ['illegal value shown for latency: Non-numeric value'],
+            result.errors)
 
     def test_results_page_displays_non_numeric_c2s_throughput(self):
-        mock_elements = {
-            'websocketButton': mock.Mock(),
-            'upload-speed': mock.Mock(text='Non-numeric value'),
-            'upload-speed-units': mock.Mock(text='kb/s'),
-            'download-speed': mock.Mock(text='34'),
-            'download-speed-units': mock.Mock(text='Mb/s'),
-            'latency': mock.Mock(text='34'),
-            'results': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_elements[id])
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
-        html5_driver.webdriver.Firefox.return_value = self.mock_driver
-
-        test_results = html5_driver.NdtHtml5SeleniumDriver(
+        self.mock_page_elements['upload-speed'] = mock.Mock(
+            text='Non-numeric value')
+        result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
             url='http://ndt.mock-server.com:7123/',
             timeout=1000).perform_test()
 
-        # And only the appropriate error object is contained in the list
-        self.assertEqual(len(test_results.errors), 1)
-        self.assertEqual(
-            test_results.errors[0].message,
-            'illegal value shown for c2s throughput: Non-numeric value')
+        self.assertIsNone(result.c2s_result.throughput)
+        self.assertEqual(2.0, result.s2c_result.throughput)
+        self.assertEqual(3.0, result.latency)
+        self.assertErrorMessagesEqual(
+            ['illegal value shown for c2s throughput: Non-numeric value'],
+            result.errors)
 
     def test_results_page_displays_non_numeric_s2c_throughput(self):
-        mock_elements = {
-            'websocketButton': mock.Mock(),
-            'upload-speed': mock.Mock(text='34'),
-            'upload-speed-units': mock.Mock(text='kb/s'),
-            'download-speed': mock.Mock(text='Non-numeric value'),
-            'download-speed-units': mock.Mock(text='Mb/s'),
-            'latency': mock.Mock(text='34'),
-            'results': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_elements[id])
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
-        html5_driver.webdriver.Firefox.return_value = self.mock_driver
-
-        test_results = html5_driver.NdtHtml5SeleniumDriver(
+        self.mock_page_elements['download-speed'] = mock.Mock(
+            text='Non-numeric value')
+        result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
             url='http://ndt.mock-server.com:7123/',
             timeout=1000).perform_test()
 
-        # And only the appropriate error object is contained in the list
-        self.assertEqual(len(test_results.errors), 1)
-        self.assertEqual(
-            test_results.errors[0].message,
-            'illegal value shown for s2c throughput: Non-numeric value')
+        self.assertEqual(1.0, result.c2s_result.throughput)
+        self.assertIsNone(result.s2c_result.throughput)
+        self.assertEqual(3.0, result.latency)
+        self.assertErrorMessagesEqual(
+            ['illegal value shown for s2c throughput: Non-numeric value'],
+            result.errors)
 
     def test_results_page_displays_non_numeric_metrics(self):
         """A results page with non-numeric metrics results in error list errors.
@@ -164,107 +176,49 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
         corresponding error objects are added to the errors list that indicate
         that each of these values is invalid.
         """
-        # We patch selenium's web driver so it always has a non numeric
-        # value as a WebElement.text attribute
-        mock_elements = {
-            'websocketButton': mock.Mock(),
-            'upload-speed': mock.Mock(text='Non-numeric value'),
-            'upload-speed-units': mock.Mock(text='kb/s'),
-            'download-speed': mock.Mock(text='Non-numeric value'),
-            'download-speed-units': mock.Mock(text='Mb/s'),
-            'latency': mock.Mock(text='Non-numeric value'),
-            'results': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_elements[id])
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
-        html5_driver.webdriver.Firefox.return_value = self.mock_driver
+        self.mock_page_elements['upload-speed'] = mock.Mock(
+            text='Non-numeric value')
+        self.mock_page_elements['download-speed'] = mock.Mock(
+            text='Non-numeric value')
+        self.mock_page_elements['latency'] = mock.Mock(text='Non-numeric value')
 
-        test_results = html5_driver.NdtHtml5SeleniumDriver(
+        result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
             url='http://ndt.mock-server.com:7123/',
             timeout=1000).perform_test()
 
-        # And the appropriate error objects are contained in
-        # the list
-        self.assertEqual(
-            test_results.errors[0].message,
-            'illegal value shown for c2s throughput: Non-numeric value')
-        self.assertEqual(
-            test_results.errors[1].message,
-            'illegal value shown for s2c throughput: Non-numeric value')
-        self.assertEqual(test_results.errors[2].message,
-                         'illegal value shown for latency: Non-numeric value')
-
-    def test_results_page_displays_numeric_latency(self):
-        """A valid (numeric) latency results in an empty errors list."""
-        # Mock so always returns a numeric value for a WebElement.text attribute
-        mock_elements = {
-            'websocketButton': mock.Mock(),
-            'upload-speed': mock.Mock(text='72'),
-            'upload-speed-units': mock.Mock(text='Mb/s'),
-            'download-speed': mock.Mock(text='72'),
-            'download-speed-units': mock.Mock(text='Mb/s'),
-            'latency': mock.Mock(text='72'),
-            'results': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_elements[id])
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
-        html5_driver.webdriver.Firefox.return_value = self.mock_driver
-
-        test_results = html5_driver.NdtHtml5SeleniumDriver(
-            browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
-
-        self.assertEqual(test_results.latency, 72.0)
-        # And an error object is not contained in the list
-        self.assertEqual(len(test_results.errors), 0)
+        self.assertIsNone(result.c2s_result.throughput)
+        self.assertIsNone(result.s2c_result.throughput)
+        self.assertIsNone(result.latency)
+        self.assertErrorMessagesEqual(
+            ['illegal value shown for c2s throughput: Non-numeric value',
+             'illegal value shown for s2c throughput: Non-numeric value',
+             'illegal value shown for latency: Non-numeric value'],
+            result.errors)
 
     def test_s2c_gbps_speed_conversion(self):
         """Test s2c speed converts from Gb/s to Mb/s correctly."""
         # If s2c speed is 72 Gb/s and c2s is speed is 34 in the browser
-        mock_elements = {
-            'websocketButton': mock.Mock(),
-            'upload-speed': mock.Mock(text='34'),
-            'upload-speed-units': mock.Mock(text='Mb/s'),
-            'download-speed': mock.Mock(text='72'),
-            'download-speed-units': mock.Mock(text='Gb/s'),
-            'latency': mock.Mock(text='34'),
-            'results': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_elements[id])
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
-        html5_driver.webdriver.Firefox.return_value = self.mock_driver
+        self.mock_page_elements['upload-speed'] = mock.Mock(text='34')
+        self.mock_page_elements['upload-speed-units'] = mock.Mock(text='Mb/s')
+        self.mock_page_elements['download-speed'] = mock.Mock(text='72')
+        self.mock_page_elements['download-speed-units'] = mock.Mock(text='Gb/s')
 
-        test_results = html5_driver.NdtHtml5SeleniumDriver(
+        result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
             url='http://ndt.mock-server.com:7123/',
             timeout=1000).perform_test()
 
         # Then s2c is converted from Gb/s to Mb/s
-        self.assertEqual(test_results.s2c_result.throughput, 72000)
+        self.assertEqual(72000.0, result.s2c_result.throughput)
         # And c2s is not
-        self.assertEqual(test_results.c2s_result.throughput, 34)
-        # And an error object is not contained in the list
-        self.assertEqual(len(test_results.errors), 0)
+        self.assertEqual(34.0, result.c2s_result.throughput)
+        self.assertEqual(3.0, result.latency)
+        self.assertErrorMessagesEqual([], result.errors)
 
     def test_invalid_throughput_unit_raises_error(self):
-        mock_elements = {
-            'websocketButton': mock.Mock(),
-            'upload-speed': mock.Mock(text='34'),
-            'upload-speed-units': mock.Mock(text='not a unit'),
-            'download-speed': mock.Mock(text='72'),
-            'download-speed-units': mock.Mock(text='Gb/s'),
-            'latency': mock.Mock(text='34'),
-            'results': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_elements[id])
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
-        html5_driver.webdriver.Firefox.return_value = self.mock_driver
+        self.mock_page_elements['upload-speed-units'] = mock.Mock(
+            text='not a unit')
 
         # And a value error is raised because the c2s throughput unit was
         # invalid.
@@ -280,207 +234,114 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
         def mock_find_element_by_id(id):
             if id == 'upload-speed':
                 raise exceptions.TimeoutException
-            mock_elements = {
-                'websocketButton': mock.Mock(),
-                'upload-speed-units': mock.Mock(text='Mb/s'),
-                'download-speed': mock.Mock(text='72'),
-                'download-speed-units': mock.Mock(text='Mb/s'),
-                'latency': mock.Mock(text='72'),
-                'results': mock.Mock(),
-            }
-            return mock_elements[id]
+            return self.mock_page_elements[id]
 
         self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_find_element_by_id(id))
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
-        html5_driver.webdriver.Firefox.return_value = self.mock_driver
-
-        test_results = html5_driver.NdtHtml5SeleniumDriver(
+            mock_find_element_by_id)
+        result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
             url='http://ndt.mock-server.com:7123/',
             timeout=1000).perform_test()
 
-        # The appropriate error object is contained in the list.
-        self.assertEqual(test_results.errors[0].message,
-                         'Test did not complete within timeout period.')
+        self.assertIsNone(result.c2s_result.throughput)
+        self.assertIsNone(result.s2c_result.throughput)
+        self.assertIsNone(result.latency)
+        self.assertErrorMessagesEqual(
+            ['Test did not complete within timeout period.'], result.errors)
 
     @mock.patch.object(html5_driver.webdriver, 'Chrome')
     def test_chrome_driver_can_be_used_for_test(self, mock_chrome):
-        mock_elements = {
-            'websocketButton': mock.Mock(),
-            'upload-speed': mock.Mock(text='34'),
-            'upload-speed-units': mock.Mock(text='Mb/s'),
-            'download-speed': mock.Mock(text='72'),
-            'download-speed-units': mock.Mock(text='Gb/s'),
-            'latency': mock.Mock(text='34'),
-            'results': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_elements[id])
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
         mock_chrome.return_value = self.mock_driver
-
-        test_results = html5_driver.NdtHtml5SeleniumDriver(
+        result = html5_driver.NdtHtml5SeleniumDriver(
             browser='chrome',
             url='http://ndt.mock-server.com:7123/',
             timeout=1000).perform_test()
 
-        # Then s2c is converted from Gb/s to Mb/s
-        self.assertEqual(test_results.s2c_result.throughput, 72000)
-        # And c2s is not
-        self.assertEqual(test_results.c2s_result.throughput, 34)
-        # And an error object is not contained in the list
-        self.assertEqual(len(test_results.errors), 0)
+        self.assertEqual(1.0, result.c2s_result.throughput)
+        self.assertEqual(2.0, result.s2c_result.throughput)
+        self.assertEqual(3.0, result.latency)
+        self.assertErrorMessagesEqual([], result.errors)
 
     @mock.patch.object(html5_driver.webdriver, 'Edge')
     def test_edge_driver_can_be_used_for_test(self, mock_edge):
-        mock_elements = {
-            'websocketButton': mock.Mock(),
-            'upload-speed': mock.Mock(text='34'),
-            'upload-speed-units': mock.Mock(text='Mb/s'),
-            'download-speed': mock.Mock(text='72'),
-            'download-speed-units': mock.Mock(text='Gb/s'),
-            'latency': mock.Mock(text='34'),
-            'results': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_elements[id])
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
         mock_edge.return_value = self.mock_driver
-
-        test_results = html5_driver.NdtHtml5SeleniumDriver(
+        result = html5_driver.NdtHtml5SeleniumDriver(
             browser='edge',
             url='http://ndt.mock-server.com:7123/',
             timeout=1000).perform_test()
 
-        # Then s2c is converted from Gb/s to Mb/s
-        self.assertEqual(test_results.s2c_result.throughput, 72000)
-        # And c2s is not
-        self.assertEqual(test_results.c2s_result.throughput, 34)
-        # And an error object is not contained in the list
-        self.assertEqual(len(test_results.errors), 0)
+        self.assertEqual(1.0, result.c2s_result.throughput)
+        self.assertEqual(2.0, result.s2c_result.throughput)
+        self.assertEqual(3.0, result.latency)
+        self.assertErrorMessagesEqual([], result.errors)
 
     @mock.patch.object(html5_driver.webdriver, 'Safari')
     def test_safari_driver_can_be_used_for_test(self, mock_safari):
-        mock_elements = {
-            'websocketButton': mock.Mock(),
-            'upload-speed': mock.Mock(text='34'),
-            'upload-speed-units': mock.Mock(text='Mb/s'),
-            'download-speed': mock.Mock(text='72'),
-            'download-speed-units': mock.Mock(text='Gb/s'),
-            'latency': mock.Mock(text='34'),
-            'results': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_elements[id])
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
         mock_safari.return_value = self.mock_driver
-
-        test_results = html5_driver.NdtHtml5SeleniumDriver(
+        result = html5_driver.NdtHtml5SeleniumDriver(
             browser='safari',
             url='http://ndt.mock-server.com:7123/',
             timeout=1000).perform_test()
 
-        # Then s2c is converted from Gb/s to Mb/s
-        self.assertEqual(test_results.s2c_result.throughput, 72000)
-        # And c2s is not
-        self.assertEqual(test_results.c2s_result.throughput, 34)
-        # And an error object is not contained in the list
-        self.assertEqual(len(test_results.errors), 0)
+        self.assertEqual(1.0, result.c2s_result.throughput)
+        self.assertEqual(2.0, result.s2c_result.throughput)
+        self.assertEqual(3.0, result.latency)
+        self.assertErrorMessagesEqual([], result.errors)
 
     def test_c2s_kbps_speed_conversion(self):
         """Test c2s speed converts from kb/s to Mb/s correctly."""
         # If c2s speed is 72 kb/s and s2c speed is 34 in the browser
-        mock_elements = {
-            'websocketButton': mock.Mock(),
-            'upload-speed': mock.Mock(text='72'),
-            'upload-speed-units': mock.Mock(text='kb/s'),
-            'download-speed': mock.Mock(text='34'),
-            'download-speed-units': mock.Mock(text='Mb/s'),
-            'latency': mock.Mock(text='34'),
-            'results': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_elements[id])
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
-        html5_driver.webdriver.Firefox.return_value = self.mock_driver
-
-        test_results = html5_driver.NdtHtml5SeleniumDriver(
+        self.mock_page_elements['upload-speed'] = mock.Mock(text='72')
+        self.mock_page_elements['upload-speed-units'] = mock.Mock(text='kb/s')
+        self.mock_page_elements['download-speed'] = mock.Mock(text='34')
+        self.mock_page_elements['download-speed-units'] = mock.Mock(text='Mb/s')
+        result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
             url='http://ndt.mock-server.com:7123/',
             timeout=1000).perform_test()
 
         # Then c2s is converted from kb/s to Mb/s
-        self.assertEqual(test_results.c2s_result.throughput, 0.072)
+        self.assertEqual(0.072, result.c2s_result.throughput)
         # And s2c is not
-        self.assertEqual(test_results.s2c_result.throughput, 34)
-        # And an error object is not contained in the list
-        self.assertEqual(len(test_results.errors), 0)
+        self.assertEqual(34.0, result.s2c_result.throughput)
+        self.assertEqual(3.0, result.latency)
+        self.assertErrorMessagesEqual([], result.errors)
 
     @freezegun.freeze_time('2016-01-01', tz_offset=0)
-    def test_ndt_test_results_records_todays_times(self):
-        mock_elements = {
-            'websocketButton': mock.Mock(),
-            'upload-speed': mock.Mock(text='72'),
-            'upload-speed-units': mock.Mock(text='kb/s'),
-            'download-speed': mock.Mock(text='72'),
-            'download-speed-units': mock.Mock(text='Mb/s'),
-            'latency': mock.Mock(text='72'),
-            'results': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_elements[id])
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
-        html5_driver.webdriver.Firefox.return_value = self.mock_driver
-
+    def test_ndt_result_records_todays_times(self):
         # When we patch datetime so it shows our current date as 2016-01-01
         self.assertEqual(datetime.datetime.now(), datetime.datetime(2016, 1, 1))
-
-        test_results = html5_driver.NdtHtml5SeleniumDriver(
+        result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
             url='http://ndt.mock-server.com:7123/',
             timeout=1000).perform_test()
 
         # Then the readings for our test start and end times occur within
         # today's date
-        self.assertEqual(test_results.start_time,
+        self.assertEqual(result.start_time,
                          datetime.datetime(2016,
                                            1,
                                            1,
                                            tzinfo=pytz.utc))
-        self.assertEqual(test_results.end_time,
+        self.assertEqual(result.end_time,
                          datetime.datetime(2016,
                                            1,
                                            1,
                                            tzinfo=pytz.utc))
 
-    def test_ndt_test_results_increments_time_correctly(self):
+    def test_ndt_result_increments_time_correctly(self):
         # Create a list of times every minute starting at 2016-1-1 8:00:00 and
         # ending at 2016-1-1 8:04:00. These will be the values that our mock
         # datetime.now() function returns.
         base_date = datetime.datetime(2016, 1, 1, 8, 0, 0, tzinfo=pytz.utc)
         dates = [base_date + datetime.timedelta(0, 60) * x for x in range(6)]
 
-        mock_elements = {
-            'websocketButton': mock.Mock(),
-            'upload-speed': mock.Mock(text='72'),
-            'upload-speed-units': mock.Mock(text='kb/s'),
-            'download-speed': mock.Mock(text='72'),
-            'download-speed-units': mock.Mock(text='Mb/s'),
-            'latency': mock.Mock(text='72'),
-            'results': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: mock_elements[id])
-        self.mock_driver.find_elements_by_xpath.return_value = [mock.Mock()]
-        html5_driver.webdriver.Firefox.return_value = self.mock_driver
-
         with mock.patch.object(html5_driver.datetime,
                                'datetime',
                                autospec=True) as mocked_datetime:
             mocked_datetime.now.side_effect = dates
 
-            test_results = html5_driver.NdtHtml5SeleniumDriver(
+            result = html5_driver.NdtHtml5SeleniumDriver(
                 browser='firefox',
                 url='http://ndt.mock-server.com:7123/',
                 timeout=1).perform_test()
@@ -490,16 +351,16 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
 
         # yapf: disable
         self.assertEqual(
-            test_results.start_time,
+            result.start_time,
             datetime.datetime(2016, 1, 1, 8, 0, 0, tzinfo=pytz.utc))
         self.assertEqual(
-            test_results.c2s_result.start_time,
+            result.c2s_result.start_time,
             datetime.datetime(2016, 1, 1, 8, 1, 0, tzinfo=pytz.utc))
         self.assertEqual(
-            test_results.s2c_result.start_time,
+            result.s2c_result.start_time,
             datetime.datetime(2016, 1, 1, 8, 3, 0, tzinfo=pytz.utc))
         self.assertEqual(
-            test_results.end_time,
+            result.end_time,
             datetime.datetime(2016, 1, 1, 8, 5, 0, tzinfo=pytz.utc))
         # yapf: enable
 


### PR DESCRIPTION
Further refactoring of HTML5 driver's unit test. In particular:

* Creates a default mock DOM in the setUp method so that each test doesn't have
  to redundantly create the elements.
* Adds a assertErrorMessagesEqual to simplify the syntax of checking error
  messages.
* Adds explicit checks on the results to verify that they are either explicitly
  None when we expect no value for a particular field or that they have the
  correct value when we expect successful parsing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/25)
<!-- Reviewable:end -->
