### PR TITLE
Fixing time logging in HTML5 driver

### DIFF
--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -19,11 +19,25 @@ import datetime
 import pytz
 from selenium import webdriver
 from selenium.webdriver.support import ui
-from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support import expected_conditions
 from selenium.common import exceptions
 
 import names
 import results
+
+# TODO(mtlynch): Define all error strings as public constants so we're not
+# duplicating strings between production code and unit test code.
+ERROR_C2S_NEVER_STARTED = 'Timed out waiting for c2s test to begin.'
+ERROR_S2C_NEVER_STARTED = 'Timed out waiting for c2s test to begin.'
+ERROR_S2C_NEVER_ENDED = 'Timed out waiting for c2s test to end.'
+
+
+class Error(Exception):
+    pass
+
+
+class UnsupportedBrowserError(Error):
+    pass
 
 
 class NdtHtml5SeleniumDriver(object):
@@ -49,23 +63,18 @@ class NdtHtml5SeleniumDriver(object):
         """
         result = results.NdtResult(start_time=None, end_time=None, errors=[])
         result.client = names.NDT_HTML5
+        result.start_time = datetime.datetime.now(pytz.utc)
 
         with contextlib.closing(_create_browser(self._browser)) as driver:
             result.browser = self._browser
             result.browser_version = driver.capabilities['version']
 
-            if not _load_url(driver, self._url, result):
-                return result
-
-            _click_start_button(driver, result)
-
-            if not _record_test_in_progress_values(result, driver,
-                                                   self._timeout):
-                return result
+            _complete_ui_flow(driver, self._url, self._timeout, result)
 
             _populate_metric_values(result, driver)
 
-            return result
+        result.end_time = datetime.datetime.now(pytz.utc)
+        return result
 
 
 def _create_browser(browser):
@@ -77,6 +86,9 @@ def _create_browser(browser):
     Returns:
         An instance of a Selenium webdriver browser class corresponding to
         the specified browser.
+
+    Raises:
+        UnsupportedBrowserError: When an invalid browser is specified.
     """
     if browser == names.FIREFOX:
         return webdriver.Firefox()
@@ -86,7 +98,7 @@ def _create_browser(browser):
         return webdriver.Edge()
     elif browser == names.SAFARI:
         return webdriver.Safari()
-    raise ValueError('Invalid browser specified: %s' % browser)
+    raise UnsupportedBrowserError('Invalid browser specified: %s' % browser)
 
 
 def _load_url(driver, url, result):
@@ -108,95 +120,93 @@ def _load_url(driver, url, result):
     return True
 
 
-def _click_start_button(driver, result):
-    """Clicks start test button and records start time.
-
-    Clicks the start test button for an NDT test and records the start time in
-    an NdtResult instance.
+def _complete_ui_flow(driver, url, timeout, result):
+    """Performs the UI flow for the NDT HTML5 test and records results.
 
     Args:
         driver: An instance of a Selenium webdriver browser class.
-        result: An instance of an NdtResult class.
+        url: URL to load to start the UI flow.
+        timeout: Maximum time (in seconds) to wait for any element to appear in
+            the flow.
+        result: NdtResult instance to populate with results from proceeding
+            through the UI flow.
+    """
+    if not _load_url(driver, url, result):
+        return
+
+    _click_start_button(driver)
+    result.c2s_result = results.NdtSingleTestResult()
+    result.s2c_result = results.NdtSingleTestResult()
+
+    if _wait_for_c2s_test_to_start(driver, timeout):
+        result.c2s_result.start_time = datetime.datetime.now(pytz.utc)
+    else:
+        result.errors.append(results.TestError(ERROR_C2S_NEVER_STARTED))
+
+    if _wait_for_s2c_test_to_start(driver, timeout):
+        result.c2s_result.end_time = datetime.datetime.now(pytz.utc)
+        result.s2c_result.start_time = datetime.datetime.now(pytz.utc)
+    else:
+        result.errors.append(results.TestError(ERROR_S2C_NEVER_STARTED))
+
+    if _wait_for_results_page_to_appear(driver, timeout):
+        result.s2c_result.end_time = datetime.datetime.now(pytz.utc)
+    else:
+        result.errors.append(results.TestError(ERROR_S2C_NEVER_ENDED))
+
+    _populate_metric_values(result, driver)
+
+
+def _click_start_button(driver):
+    """Clicks the "Start Test" button in the web UI.
+
+    Args:
+        driver: An instance of a Selenium webdriver browser class.
     """
     driver.find_element_by_id('websocketButton').click()
 
     start_button = driver.find_elements_by_xpath(
         "//*[contains(text(), 'Start Test')]")[0]
     start_button.click()
-    result.start_time = datetime.datetime.now(pytz.utc)
 
 
-def _record_test_in_progress_values(result, driver, timeout):
-    """Records values that are measured while the NDT test is in progress.
+def _wait_for_c2s_test_to_start(driver, timeout):
+    # Wait until the 'Now Testing your upload speed' banner is displayed.
+    upload_speed_text = driver.find_elements_by_xpath(
+        "//*[contains(text(), 'your upload speed')]")[0]
+    return _wait_until_element_is_visible(driver, upload_speed_text, timeout)
 
-    Measures s2c_start_time, c2s_end_time, and end_time, which are stored in
-    an instance of NdtResult. These times are measured while the NDT test is
-    in progress.
+
+def _wait_for_s2c_test_to_start(driver, timeout):
+    # Wait until the 'Now Testing your download speed' banner is displayed.
+    download_speed_text = driver.find_elements_by_xpath(
+        "//*[contains(text(), 'your download speed')]")[0]
+    return _wait_until_element_is_visible(driver, download_speed_text, timeout)
+
+
+def _wait_for_results_page_to_appear(driver, timeout):
+    results_text = driver.find_element_by_id('results')
+    return _wait_until_element_is_visible(driver, results_text, timeout)
+
+
+def _wait_until_element_is_visible(driver, element, timeout):
+    """Waits until a DOM element is visible in within a given timeout.
 
     Args:
-        result: An instance of NdtResult.
         driver: An instance of a Selenium webdriver browser class.
-        timeout: The number of seconds that the driver will wait for
-            each element to become visible before timing out.
+        element: A selenium webdriver element.
+        timeout: The maximum time to wait (in seconds).
 
     Returns:
-        True if recording the measured values was successful, False if otherwise.
+        True if the element became visible within the timeout.
     """
     try:
-        # wait until 'Now Testing your upload speed' is displayed
-        upload_speed_text = driver.find_elements_by_xpath(
-            "//*[contains(text(), 'your upload speed')]")[0]
-        result.c2s_result = results.NdtSingleTestResult()
-        result.c2s_result.start_time = _record_time_when_element_displayed(
-            upload_speed_text,
+        ui.WebDriverWait(
             driver,
-            timeout=timeout)
-        result.c2s_result.end_time = datetime.datetime.now(pytz.utc)
-
-        # wait until 'Now Testing your download speed' is displayed
-        download_speed_text = driver.find_elements_by_xpath(
-            "//*[contains(text(), 'your download speed')]")[0]
-        result.s2c_result = results.NdtSingleTestResult()
-        result.s2c_result.start_time = _record_time_when_element_displayed(
-            download_speed_text,
-            driver,
-            timeout=timeout)
-
-        # wait until the results page appears
-        results_text = driver.find_element_by_id('results')
-        result.s2c_result.end_time = datetime.datetime.now(pytz.utc)
-        result.end_time = _record_time_when_element_displayed(results_text,
-                                                              driver,
-                                                              timeout=timeout)
+            timeout=timeout).until(expected_conditions.visibility_of(element))
     except exceptions.TimeoutException:
-        result.errors.append(results.TestError(
-            'Test did not complete within timeout period.'))
         return False
     return True
-
-
-def _record_time_when_element_displayed(element, driver, timeout):
-    """Return the time when the specified element is displayed.
-
-    The Selenium WebDriver checks whether the specified element is visible. If
-    it becomes visible before the request has timed out, the timestamp of the
-    time when the element becomes visible is returned.
-
-    Args:
-        element: A selenium webdriver element.
-        driver: An instance of a Selenium webdriver browser class.
-        timeout: The number of seconds that the driver will wait for
-            each element to become visible before timing out.
-
-    Returns:
-        A datetime object with a timezone information attribute.
-
-    Raises:
-        TimeoutException: If the element does not become visible before the
-            timeout time passes.
-    """
-    ui.WebDriverWait(driver, timeout=timeout).until(EC.visibility_of(element))
-    return datetime.datetime.now(pytz.utc)
 
 
 def _populate_metric_values(result, driver):

--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -32,14 +32,6 @@ ERROR_S2C_NEVER_STARTED = 'Timed out waiting for c2s test to begin.'
 ERROR_S2C_NEVER_ENDED = 'Timed out waiting for c2s test to end.'
 
 
-class Error(Exception):
-    pass
-
-
-class UnsupportedBrowserError(Error):
-    pass
-
-
 class NdtHtml5SeleniumDriver(object):
 
     def __init__(self, browser, url, timeout):
@@ -86,9 +78,6 @@ def _create_browser(browser):
     Returns:
         An instance of a Selenium webdriver browser class corresponding to
         the specified browser.
-
-    Raises:
-        UnsupportedBrowserError: When an invalid browser is specified.
     """
     if browser == names.FIREFOX:
         return webdriver.Firefox()
@@ -98,7 +87,7 @@ def _create_browser(browser):
         return webdriver.Edge()
     elif browser == names.SAFARI:
         return webdriver.Safari()
-    raise UnsupportedBrowserError('Invalid browser specified: %s' % browser)
+    raise ValueError('Invalid browser specified: %s' % browser)
 
 
 def _load_url(driver, url, result):

--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -63,8 +63,6 @@ class NdtHtml5SeleniumDriver(object):
 
             _complete_ui_flow(driver, self._url, self._timeout, result)
 
-            _populate_metric_values(result, driver)
-
         result.end_time = datetime.datetime.now(pytz.utc)
         return result
 
@@ -121,6 +119,7 @@ def _complete_ui_flow(driver, url, timeout, result):
             through the UI flow.
     """
     if not _load_url(driver, url, result):
+
         return
 
     _click_start_button(driver)

--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -178,7 +178,7 @@ def _wait_for_results_page_to_appear(driver, timeout):
 
 
 def _wait_until_element_is_visible(driver, element, timeout):
-    """Waits until a DOM element is visible in within a given timeout.
+    """Waits until a DOM element is visible within a given timeout.
 
     Args:
         driver: An instance of a Selenium webdriver browser class.

--- a/client_wrapper/results.py
+++ b/client_wrapper/results.py
@@ -59,10 +59,13 @@ class NdtResult(object):
     """Represents the results of a complete NDT HTML5 client test.
 
     Attributes:
-        start_time: The datetime at which tests were initiated (i.e. the time
-            the driver pushed the 'Start Test' button).
-        end_time: The datetime at which the tests completed (i.e. the time the
-            results page loaded).
+        start_time: The datetime at which the NDT client was launched. This is
+            time at which the client wrapper begins running a particular client,
+            but is not necessarily the time at which the client itself initiated
+            a test.
+        end_time: The datetime at which the NDT client completed. This should be
+            equal to the end_time of the client's last test or the time of a
+            fatal error in the client.
         errors: A list of TestError objects representing any errors encountered
             during the tests (or an empty list if all tests were successful).
         c2s_result: The NdtSingleResult for the c2s (upload) test (or None if no

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,1 @@
 mock==1.3.0
-freezegun==0.3.6

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -136,7 +136,7 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
             browser='not_a_browser',
             url='http://ndt.mock-server.com:7123',
             timeout=1)
-        with self.assertRaises(html5_driver.UnsupportedBrowserError):
+        with self.assertRaises(ValueError):
             selenium_driver.perform_test()
 
     def test_results_page_displays_non_numeric_latency(self):

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -18,21 +18,18 @@ import unittest
 
 import mock
 import pytz
-import freezegun
-import selenium.webdriver.support.expected_conditions as selenium_expected_conditions
 from selenium.common import exceptions
-
 from client_wrapper import html5_driver
 
 
 class NdtHtml5SeleniumDriverTest(unittest.TestCase):
 
     def setUp(self):
-        self.mock_visibility = mock.patch.object(selenium_expected_conditions,
-                                                 'visibility_of',
-                                                 autospec=True)
-        self.addCleanup(self.mock_visibility.stop)
-        self.mock_visibility.start()
+        visibility_patcher = mock.patch.object(html5_driver.expected_conditions,
+                                               'visibility_of',
+                                               autospec=True)
+        self.addCleanup(visibility_patcher.stop)
+        visibility_patcher.start()
 
         self.mock_driver = mock.Mock()
         self.mock_driver.capabilities = {'version': 'mock_version'}
@@ -103,8 +100,8 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
         self.assertErrorMessagesEqual(
             ['Failed to load test UI.'], result.errors)
 
-    def test_test_in_progress_timeout_throws_error(self):
-        # Call to webdriverwait throws timeout exception
+    def test_test_in_progress_timeout_yields_timeout_errors(self):
+        """If each test times out, expect an error for each timeout."""
         with mock.patch.object(html5_driver.ui,
                                'WebDriverWait',
                                side_effect=exceptions.TimeoutException,
@@ -115,14 +112,31 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
                 timeout=1).perform_test()
 
         self.assertErrorMessagesEqual(
-            ['Test did not complete within timeout period.'], result.errors)
+            [html5_driver.ERROR_C2S_NEVER_STARTED,
+             html5_driver.ERROR_S2C_NEVER_STARTED,
+             html5_driver.ERROR_S2C_NEVER_ENDED], result.errors)
+
+    def test_c2s_start_timeout_yields_errors(self):
+        """If waiting for just c2s start times out, expect just one error."""
+        with mock.patch.object(html5_driver.ui,
+                               'WebDriverWait',
+                               autospec=True) as mock_wait:
+            mock_wait.side_effect = [exceptions.TimeoutException, mock.Mock(),
+                                     mock.Mock()]
+            result = html5_driver.NdtHtml5SeleniumDriver(
+                browser='firefox',
+                url='http://ndt.mock-server.com:7123/',
+                timeout=1).perform_test()
+
+        self.assertErrorMessagesEqual(
+            [html5_driver.ERROR_C2S_NEVER_STARTED], result.errors)
 
     def test_unrecognized_browser_raises_error(self):
         selenium_driver = html5_driver.NdtHtml5SeleniumDriver(
             browser='not_a_browser',
             url='http://ndt.mock-server.com:7123',
             timeout=1)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(html5_driver.UnsupportedBrowserError):
             selenium_driver.perform_test()
 
     def test_results_page_displays_non_numeric_latency(self):
@@ -288,62 +302,52 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
         self.assertEqual(3.0, result.latency)
         self.assertErrorMessagesEqual([], result.errors)
 
-    @freezegun.freeze_time('2016-01-01', tz_offset=0)
-    def test_ndt_result_records_todays_times(self):
-        # When we patch datetime so it shows our current date as 2016-01-01
-        self.assertEqual(datetime.datetime.now(), datetime.datetime(2016, 1, 1))
-        result = html5_driver.NdtHtml5SeleniumDriver(
-            browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
-
-        # Then the readings for our test start and end times occur within
-        # today's date
-        self.assertEqual(result.start_time,
-                         datetime.datetime(2016,
-                                           1,
-                                           1,
-                                           tzinfo=pytz.utc))
-        self.assertEqual(result.end_time,
-                         datetime.datetime(2016,
-                                           1,
-                                           1,
-                                           tzinfo=pytz.utc))
-
     def test_ndt_result_increments_time_correctly(self):
-        # Create a list of times every minute starting at 2016-1-1 8:00:00 and
-        # ending at 2016-1-1 8:04:00. These will be the values that our mock
-        # datetime.now() function returns.
-        base_date = datetime.datetime(2016, 1, 1, 8, 0, 0, tzinfo=pytz.utc)
-        dates = [base_date + datetime.timedelta(0, 60) * x for x in range(6)]
+        # Create a list of mock times to be returned by datetime.now().
+        times = []
+        for i in range(10):
+            times.append(datetime.datetime(2016, 1, 1, 0, 0, i))
 
         with mock.patch.object(html5_driver.datetime,
                                'datetime',
                                autospec=True) as mocked_datetime:
-            mocked_datetime.now.side_effect = dates
+            # Patch datetime.now to return the next mock time on every call to
+            # now().
+            mocked_datetime.now.side_effect = times
+
+            # Modify the Firefox mock to increment the clock forward one call.
+            def mock_firefox():
+                datetime.datetime.now(pytz.utc)
+                return self.mock_driver
+
+            html5_driver.webdriver.Firefox.side_effect = mock_firefox
+
+            # Modify the visibility_of mock to increment the clock forward one
+            # call.
+            def mock_visibility_of(_):
+                datetime.datetime.now(pytz.utc)
+                return mock.Mock()
+
+            html5_driver.expected_conditions.visibility_of.side_effect = (
+                mock_visibility_of)
 
             result = html5_driver.NdtHtml5SeleniumDriver(
                 browser='firefox',
                 url='http://ndt.mock-server.com:7123/',
                 timeout=1).perform_test()
 
-        # And the sequence of returned values follows the expected timeline
-        # that the readings are taken in.
-
-        # yapf: disable
-        self.assertEqual(
-            result.start_time,
-            datetime.datetime(2016, 1, 1, 8, 0, 0, tzinfo=pytz.utc))
-        self.assertEqual(
-            result.c2s_result.start_time,
-            datetime.datetime(2016, 1, 1, 8, 1, 0, tzinfo=pytz.utc))
-        self.assertEqual(
-            result.s2c_result.start_time,
-            datetime.datetime(2016, 1, 1, 8, 3, 0, tzinfo=pytz.utc))
-        self.assertEqual(
-            result.end_time,
-            datetime.datetime(2016, 1, 1, 8, 5, 0, tzinfo=pytz.utc))
-        # yapf: enable
+        # Verify the recorded times matches the expected sequence.
+        self.assertEqual(times[0], result.start_time)
+        # times[1] is the call from mock_firefox
+        # times[2] is the check for visibility of c2s test start
+        self.assertEqual(times[3], result.c2s_result.start_time)
+        # times[4] is the check for visibility of s2c test start (start of s2c
+        #   marks the end of c2s)
+        self.assertEqual(times[5], result.c2s_result.end_time)
+        self.assertEqual(times[6], result.s2c_result.start_time)
+        # times[7] is the check for visibility of results page
+        self.assertEqual(times[8], result.s2c_result.end_time)
+        self.assertEqual(times[9], result.end_time)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This makes a few changes to recording timestamps during the test that are a
bit intermixed in the code:

1. Changes recording of start time and end time so that they record when the
underlying client process began and ended, not when the the actual tests
began (the revised behavior matches the spec).
2. Changes recording of s2c/c2s end_time values so that it actually waits for
the element it's waiting for before recording the time (it would previously
record the time without waiting, which was a bug and caused it to record
incorrect times).

In addition, refactors html_driver a bit so that there is less mixing of
abstraction layers within functions.

Lastly, deletes the freezegun unit test as it was not providing additional
coverage over the final timing test and it's an additional unneeded
dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/27)
<!-- Reviewable:end -->
