### PR TITLE
Fixing populate_metric_values to assume no timeouts

### DIFF
--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -63,8 +63,7 @@ class NdtHtml5SeleniumDriver(object):
                                                    self._timeout):
                 return result
 
-            if not _populate_metric_values(result, driver):
-                return result
+            _populate_metric_values(result, driver)
 
             return result
 
@@ -204,42 +203,28 @@ def _populate_metric_values(result, driver):
     """Populates NdtResult with metrics from page, checks values are valid.
 
     Populates the NdtResult instance with metrics from the NDT test page. Checks
-    thatthe values for upload (c2s) throughput, download (s2c) throughput, and
+    that the values for upload (c2s) throughput, download (s2c) throughput, and
     latency within the NdtResult instance dict are valid.
 
     Args:
         result: An instance of NdtResult.
         driver: An instance of a Selenium webdriver browser class.
-
-    Returns:
-        True if populating metrics and checking their values was successful.
-            False if otherwise.
     """
-    try:
-        c2s_throughput = driver.find_element_by_id('upload-speed').text
-        c2s_throughput_units = driver.find_element_by_id(
-            'upload-speed-units').text
+    c2s_throughput = driver.find_element_by_id('upload-speed').text
+    c2s_throughput_units = driver.find_element_by_id('upload-speed-units').text
 
-        result.c2s_result.throughput = _parse_throughput(
-            result.errors, c2s_throughput, c2s_throughput_units,
-            'c2s throughput')
+    result.c2s_result.throughput = _parse_throughput(
+        result.errors, c2s_throughput, c2s_throughput_units, 'c2s throughput')
 
-        s2c_throughput = driver.find_element_by_id('download-speed').text
+    s2c_throughput = driver.find_element_by_id('download-speed').text
 
-        s2c_throughput_units = driver.find_element_by_id(
-            'download-speed-units').text
-        result.s2c_result.throughput = _parse_throughput(
-            result.errors, s2c_throughput, s2c_throughput_units,
-            's2c throughput')
+    s2c_throughput_units = driver.find_element_by_id(
+        'download-speed-units').text
+    result.s2c_result.throughput = _parse_throughput(
+        result.errors, s2c_throughput, s2c_throughput_units, 's2c throughput')
 
-        result.latency = driver.find_element_by_id('latency').text
-        result.latency = _validate_metric(result.errors, result.latency,
-                                          'latency')
-    except exceptions.TimeoutException:
-        result.errors.append(results.TestError(
-            'Test did not complete within timeout period.'))
-        return False
-    return True
+    result.latency = driver.find_element_by_id('latency').text
+    result.latency = _validate_metric(result.errors, result.latency, 'latency')
 
 
 def _parse_throughput(errors, throughput, throughput_units,

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -228,27 +228,6 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
                 url='http://ndt.mock-server.com:7123/',
                 timeout=1000).perform_test()
 
-    def test_reading_in_result_page_timeout_throws_error(self):
-        # Simulate a timeout exception when the driver attempts to read the
-        # metric page.
-        def mock_find_element_by_id(id):
-            if id == 'upload-speed':
-                raise exceptions.TimeoutException
-            return self.mock_page_elements[id]
-
-        self.mock_driver.find_element_by_id.side_effect = (
-            mock_find_element_by_id)
-        result = html5_driver.NdtHtml5SeleniumDriver(
-            browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
-
-        self.assertIsNone(result.c2s_result.throughput)
-        self.assertIsNone(result.s2c_result.throughput)
-        self.assertIsNone(result.latency)
-        self.assertErrorMessagesEqual(
-            ['Test did not complete within timeout period.'], result.errors)
-
     @mock.patch.object(html5_driver.webdriver, 'Chrome')
     def test_chrome_driver_can_be_used_for_test(self, mock_chrome):
         mock_chrome.return_value = self.mock_driver


### PR DESCRIPTION
The _populate_metric_values function is designed to catch timeout exceptions,
but it doesn't do anything that could cause a timeout exception, so this
check is unnecessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/29)
<!-- Reviewable:end -->
