### PR TITLE
Gracefully handling invalid throughput units

### DIFF
--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -273,8 +273,8 @@ def _parse_throughput(errors, throughput, throughput_units,
         elif throughput_units == 'Mb/s':
             return throughput
         else:
-            raise ValueError('Invalid throughput unit specified: %s' %
-                             throughput_units)
+            errors.append(results.TestError(
+                'Invalid throughput unit specified: %s' % throughput_units))
     return None
 
 

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -216,17 +216,19 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
         self.assertEqual(3.0, result.latency)
         self.assertErrorMessagesEqual([], result.errors)
 
-    def test_invalid_throughput_unit_raises_error(self):
-        self.mock_page_elements['upload-speed-units'] = mock.Mock(
-            text='not a unit')
+    def test_invalid_throughput_unit_yields_error(self):
+        self.mock_page_elements['upload-speed-units'] = mock.Mock(text='banana')
 
-        # And a value error is raised because the c2s throughput unit was
-        # invalid.
-        with self.assertRaises(ValueError):
-            html5_driver.NdtHtml5SeleniumDriver(
-                browser='firefox',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1000).perform_test()
+        result = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1000).perform_test()
+
+        self.assertIsNone(result.c2s_result.throughput)
+        self.assertEqual(2.0, result.s2c_result.throughput)
+        self.assertEqual(3.0, result.latency)
+        self.assertErrorMessagesEqual(
+            ['Invalid throughput unit specified: banana'], result.errors)
 
     def test_reading_in_result_page_timeout_throws_error(self):
         # Simulate a timeout exception when the driver attempts to read the


### PR DESCRIPTION
This modifies the code so that if it encounters a throughput unit on the
results page that isn't one of (Gbps, Mbps, kbps), it logs the error in the
results, but it is not a fatal exception that crashes the program.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/30)
<!-- Reviewable:end -->
