### PR TITLE
Fixing time logging in HTML5 driver

### DIFF
--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -113,7 +113,7 @@ def _complete_ui_flow(driver, url, timeout, result):
     Args:
         driver: An instance of a Selenium webdriver browser class.
         url: URL to load to start the UI flow.
-        timeout: Maximum time (in seconds) to wait for any element to appear in
+        timeout: Maximum time (in seconds) to wait for an element to appear in
             the flow.
         result: NdtResult instance to populate with results from proceeding
             through the UI flow.

--- a/client_wrapper/results.py
+++ b/client_wrapper/results.py
@@ -59,10 +59,13 @@ class NdtResult(object):
     """Represents the results of a complete NDT HTML5 client test.
 
     Attributes:
-        start_time: The datetime at which tests were initiated (i.e. the time
-            the driver pushed the 'Start Test' button).
-        end_time: The datetime at which the tests completed (i.e. the time the
-            results page loaded).
+        start_time: The datetime at which the NDT client was launched. This is
+            time at which the client wrapper begins running a particular client,
+            but is not necessarily the time at which the client itself initiated
+            a test.
+        end_time: The datetime at which the NDT client completed. This should be
+            equal to the end_time of the client's last test or the time of a
+            fatal error in the client.
         errors: A list of TestError objects representing any errors encountered
             during the tests (or an empty list if all tests were successful).
         c2s_result: The NdtSingleResult for the c2s (upload) test (or None if no

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,1 @@
 mock==1.3.0
-freezegun==0.3.6


### PR DESCRIPTION
This makes a few changes to recording timestamps during the test that are a
bit intermixed in the code:

1. Changes recording of start time and end time so that they record when the
underlying client process began and ended, not when the the actual tests began
(the revised behavior matches the spec).

2. Changes recording of s2c/c2s end_time values so that it actually waits for the
element it's waiting for before recording the time (it would previously record
the time without waiting, which was a bug and caused it to record incorrect
times).

In addition, refactors html_driver a bit so that there is less mixing of
abstraction layers within functions.

Lastly, deletes the freezegun unit test as it was not providing additional
coverage over the final timing test and it's an additional unneeded
dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/32)
<!-- Reviewable:end -->
