### PR TITLE
Adding a JSON decoder for NdtResult objects

### DIFF
--- a/client_wrapper/result_decoder.py
+++ b/client_wrapper/result_decoder.py
@@ -1,0 +1,79 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import dateutil.parser
+
+import results
+
+
+class NdtResultDecoder(json.JSONDecoder):
+    """Decodes a JSON string into an NdtResult instance."""
+
+    def __init__(self):
+        json.JSONDecoder.__init__(self, object_hook=_dict_to_object)
+
+
+def _dict_to_object(d):
+    """Converts dictionary items in an NdtResult JSON string into objects."""
+    # Check if this is a TestError dict.
+    if ('timestamp' in d) and ('message' in d):
+        return _decode_error(d)
+    return _decode_ndt_result(d)
+
+
+def _decode_error(error):
+    """Decodes a dictionary into a TestError instance."""
+    return results.TestError(error['message'], _decode_time(error['timestamp']))
+
+
+def _decode_ndt_result(result):
+    """Decodes a dictionary into an NdtResult instance."""
+    return results.NdtResult(
+        start_time=_decode_time(result['start_time']),
+        end_time=_decode_time(result['end_time']),
+        client=result['client'],
+        client_version=result['client_version'],
+        os=result['os'],
+        os_version=result['os_version'],
+        browser=result['browser'],
+        browser_version=result['browser_version'],
+        c2s_result=results.NdtSingleTestResult(
+            throughput=result['c2s_throughput'],
+            start_time=_decode_time(result['c2s_start_time']),
+            end_time=_decode_time(result['c2s_end_time'])),
+        s2c_result=results.NdtSingleTestResult(
+            throughput=result['s2c_throughput'],
+            start_time=_decode_time(result['s2c_start_time']),
+            end_time=_decode_time(result['s2c_end_time'])),
+        latency=result['latency'],
+        errors=result['errors'])
+
+
+def _decode_time(time):
+    """Decodes a time string
+
+    Args:
+        time: A time in ISO-8601 string format.
+
+    Returns:
+        A datetime corresponding to the specified time or None if time was None
+        or an empty string.
+    """
+    if not time:
+        return None
+    # We need to use dateutil to parse because datetime.strptime can't parse
+    # time zones.
+    return dateutil.parser.parse(time)

--- a/client_wrapper/result_decoder.py
+++ b/client_wrapper/result_decoder.py
@@ -20,7 +20,12 @@ import results
 
 
 class NdtResultDecoder(json.JSONDecoder):
-    """Decodes a JSON string into an NdtResult instance."""
+    """Decodes a JSON string into an NdtResult instance.
+
+    The decoder assumes that the input is valid JSON and that the JSON
+    represents a valid NdtResult (where all required fields are defined and all
+    defined fields have legal values).
+    """
 
     def __init__(self):
         json.JSONDecoder.__init__(self, object_hook=_dict_to_object)

--- a/client_wrapper/results.py
+++ b/client_wrapper/results.py
@@ -21,7 +21,8 @@ class NdtSingleTestResult(object):
     """Result of a single NDT test.
 
     Attributes:
-        throughput: The final recorded throughput (in Mbps).
+        throughput: The final recorded throughput (in Mbps) (or None if the test
+            did not complete).
         start_time: The datetime when the test began (or None if the test
             never began).
         end_time: The datetime when the test competed (or None if the test
@@ -42,11 +43,11 @@ class NdtSingleTestResult(object):
         return not self.__eq__(other)
 
     def __str__(self):
-        return ('{{throughput={throughput}, '
+        return ('[throughput={throughput}, '
                 'start_time={start_time}, '
-                'end_time={end_time}}}').format(throughput=self.throughput,
-                                                start_time=self.start_time,
-                                                end_time=self.end_time)
+                'end_time={end_time}]').format(throughput=self.throughput,
+                                               start_time=self.start_time,
+                                               end_time=self.end_time)
 
 
 class TestError(object):
@@ -69,7 +70,7 @@ class TestError(object):
         return not self.__eq__(other)
 
     def __str__(self):
-        return '{{message={message}, timestamp={timestamp}}}'.format(
+        return '[message={message}, timestamp={timestamp}]'.format(
             message=self.message,
             timestamp=self.timestamp)
 
@@ -95,10 +96,8 @@ class NdtResult(object):
             fatal error in the client.
         errors: A list of TestError objects representing any errors encountered
             during the tests (or an empty list if all tests were successful).
-        c2s_result: The NdtSingleResult for the c2s (upload) test (or None if no
-            result was recorded).
-        s2c_result: The NdtSingleResult for the s2c (download) test (or None if
-            no result was recorded).
+        c2s_result: The NdtSingleResult for the c2s (upload) test.
+        s2c_result: The NdtSingleResult for the s2c (download) test.
         latency: The reported latency (in milliseconds) or None if the test did
             not complete.
         os: Name of OS in which the test ran (e.g. "Windows").
@@ -155,7 +154,7 @@ class NdtResult(object):
         return not self.__eq__(other)
 
     def __str__(self):
-        return ('{{start_time={start_time}, '
+        return ('[start_time={start_time}, '
                 'end_time={end_time}, '
                 'errors={errors}, '
                 'c2s_result={c2s_result}, '
@@ -166,7 +165,7 @@ class NdtResult(object):
                 'client={client}, '
                 'client_version={client_version}, '
                 'browser={browser}, '
-                'browser_version={browser_version}}}').format(
+                'browser_version={browser_version}]').format(
                     start_time=self.start_time,
                     end_time=self.end_time,
                     errors=[str(e) for e in self.errors],

--- a/client_wrapper/results.py
+++ b/client_wrapper/results.py
@@ -33,6 +33,21 @@ class NdtSingleTestResult(object):
         self.start_time = start_time
         self.end_time = end_time
 
+    def __eq__(self, other):
+        return all(((self.throughput == other.throughput),
+                    (self.start_time == other.start_time),
+                    (self.end_time == other.end_time)))  # yapf: disable
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __str__(self):
+        return ('{{throughput={throughput}, '
+                'start_time={start_time}, '
+                'end_time={end_time}}}').format(throughput=self.throughput,
+                                                start_time=self.start_time,
+                                                end_time=self.end_time)
+
 
 class TestError(object):
     """Log message of an error encountered in the test.
@@ -45,6 +60,18 @@ class TestError(object):
     def __init__(self, message, timestamp=datetime.datetime.now(pytz.utc)):
         self._message = message
         self._timestamp = timestamp
+
+    def __eq__(self, other):
+        return all(((self.message == other.message),
+                    (self.timestamp == other.timestamp)))  # yapf: disable
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __str__(self):
+        return '{{message={message}, timestamp={timestamp}}}'.format(
+            message=self.message,
+            timestamp=self.timestamp)
 
     @property
     def message(self):
@@ -88,23 +115,67 @@ class NdtResult(object):
                  start_time=None,
                  end_time=None,
                  errors=[],
-                 c2s_result=None,
-                 s2c_result=None,
-                 latency=None):
+                 c2s_result=NdtSingleTestResult(),
+                 s2c_result=NdtSingleTestResult(),
+                 latency=None,
+                 os=None,
+                 os_version=None,
+                 client=None,
+                 client_version=None,
+                 browser=None,
+                 browser_version=None):
         self.start_time = start_time
         self.end_time = end_time
         self.c2s_result = c2s_result
         self.s2c_result = s2c_result
         self.errors = errors
         self.latency = latency
-        self.os = None
-        self.os_version = None
-        self.client = None
-        self.client_version = None
-        self.browser = None
-        self.browser_version = None
+        self.os = os
+        self.os_version = os_version
+        self.client = client
+        self.client_version = client_version
+        self.browser = browser
+        self.browser_version = browser_version
+
+    def __eq__(self, other):
+        return all((
+            (self.start_time == other.start_time),
+            (self.end_time == other.end_time),
+            (self.c2s_result == other.c2s_result),
+            (self.s2c_result == other.s2c_result),
+            (self.latency == other.latency),
+            (self.os == other.os),
+            (self.os_version == other.os_version),
+            (self.client == other.client),
+            (self.client_version == other.client_version),
+            (self.browser == other.browser),
+            (self.browser_version == other.browser_version)))  # yapf: disable
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     def __str__(self):
-        return 'NDT Results:\n Start Time: %s,\n End Time: %s'\
-        ',\n Latency: %s, \nErrors: %s' % (
-            self.start_time, self.end_time, self.latency, self.errors)
+        return ('{{start_time={start_time}, '
+                'end_time={end_time}, '
+                'errors={errors}, '
+                'c2s_result={c2s_result}, '
+                's2c_result={s2c_result}, '
+                'latency={latency}, '
+                'os={os}, '
+                'os_version={os_version}, '
+                'client={client}, '
+                'client_version={client_version}, '
+                'browser={browser}, '
+                'browser_version={browser_version}}}').format(
+                    start_time=self.start_time,
+                    end_time=self.end_time,
+                    errors=[str(e) for e in self.errors],
+                    c2s_result=str(self.c2s_result),
+                    s2c_result=str(self.s2c_result),
+                    latency=self.latency,
+                    os=self.os,
+                    os_version=self.os_version,
+                    client=self.client,
+                    client_version=self.client_version,
+                    browser=self.browser,
+                    browser_version=self.browser_version)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-dateutil
+python-dateutil
 pytz==2016.2
 selenium==2.53.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-selenium==2.53.1
+dateutil
 pytz==2016.2
+selenium==2.53.1

--- a/tests/test_result_decoder.py
+++ b/tests/test_result_decoder.py
@@ -1,0 +1,126 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import datetime
+import unittest
+
+import pytz
+
+from client_wrapper import result_decoder
+from client_wrapper import results
+
+
+class NdtResultDecoderTest(unittest.TestCase):
+
+    def setUp(self):
+        self.decoder = result_decoder.NdtResultDecoder()
+
+    def test_decodes_correctly_when_only_required_fields_are_set(self):
+        encoded = """
+{
+    "start_time": "2016-02-26T15:51:23.452234Z",
+    "end_time": "2016-02-26T15:59:33.284345Z",
+    "client": "mock_client",
+    "client_version": "mock_client_version",
+    "browser": null,
+    "browser_version": null,
+    "os": "mock_os",
+    "os_version": "mock_os_version",
+    "c2s_start_time": null,
+    "c2s_end_time": null,
+    "c2s_throughput": null,
+    "s2c_start_time": null,
+    "s2c_end_time": null,
+    "s2c_throughput": null,
+    "latency": null,
+    "errors": []
+}"""
+
+        decoded_expected = results.NdtResult(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
+                                       pytz.utc),
+            client='mock_client',
+            client_version='mock_client_version',
+            os='mock_os',
+            os_version='mock_os_version')
+
+        decoded_actual = self.decoder.decode(encoded)
+        self.assertEqual(decoded_expected, decoded_actual)
+
+    def test_decodes_fully_populated_result_correctly(self):
+        encoded = """
+{
+    "start_time": "2016-02-26T15:51:23.452234Z",
+    "end_time": "2016-02-26T15:59:33.284345Z",
+    "client": "mock_client",
+    "client_version": "mock_client_version",
+    "browser": "mock_browser",
+    "browser_version": "mock_browser_version",
+    "os": "mock_os",
+    "os_version": "mock_os_version",
+    "c2s_start_time": "2016-02-26T15:51:24.123456Z",
+    "c2s_end_time": "2016-02-26T15:51:34.123456Z",
+    "c2s_throughput": 10.127,
+    "s2c_start_time": "2016-02-26T15:51:35.123456Z",
+    "s2c_end_time": "2016-02-26T15:51:45.123456Z",
+    "s2c_throughput": 98.235,
+    "latency": 23.8,
+    "errors": [
+        {
+            "timestamp": "2016-02-26T15:53:29.123456Z",
+            "message": "mock error message 1"
+        },
+        {
+            "timestamp": "2016-02-26T15:53:30.654321Z",
+            "message": "mock error message 2"
+        }
+    ]
+}"""
+
+        decoded_expected = results.NdtResult(
+            start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
+                                         pytz.utc),
+            end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
+                                       pytz.utc),
+            client='mock_client',
+            client_version='mock_client_version',
+            os='mock_os',
+            os_version='mock_os_version',
+            c2s_result=results.NdtSingleTestResult(start_time=datetime.datetime(
+                2016, 2, 26, 15, 51, 24, 123456, pytz.utc),
+                                                   end_time=datetime.datetime(
+                                                       2016, 2, 26, 15, 51, 34,
+                                                       123456, pytz.utc),
+                                                   throughput=10.127),
+            s2c_result=results.NdtSingleTestResult(start_time=datetime.datetime(
+                2016, 2, 26, 15, 51, 35, 123456, pytz.utc),
+                                                   end_time=datetime.datetime(
+                                                       2016, 2, 26, 15, 51, 45,
+                                                       123456, pytz.utc),
+                                                   throughput=98.235),
+            latency=23.8,
+            browser='mock_browser',
+            browser_version='mock_browser_version',
+            errors=[
+                results.TestError('mock error message 1', datetime.datetime(
+                    2016, 2, 26, 15, 53, 29, 123456, pytz.utc)),
+                results.TestError('mock error message 2', datetime.datetime(
+                    2016, 2, 26, 15, 53, 30, 654321, pytz.utc))
+            ])
+
+        decoded_actual = self.decoder.decode(encoded)
+        self.assertEqual(decoded_expected, decoded_actual)

--- a/tests/test_result_encoder.py
+++ b/tests/test_result_encoder.py
@@ -23,16 +23,6 @@ from client_wrapper import result_encoder
 from client_wrapper import results
 
 
-def create_ndt_result(start_time, end_time, client, client_version, os,
-                      os_version):
-    result = results.NdtResult(start_time=start_time, end_time=end_time)
-    result.client = client
-    result.client_version = client_version
-    result.os = os
-    result.os_version = os_version
-    return result
-
-
 class NdtResultEncoderTest(unittest.TestCase):
 
     def setUp(self):
@@ -44,7 +34,7 @@ class NdtResultEncoderTest(unittest.TestCase):
         self.assertDictEqual(json.loads(expected), json.loads(actual))
 
     def test_encodes_correctly_when_only_required_fields_are_set(self):
-        result = create_ndt_result(
+        result = results.NdtResult(
             start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
                                          pytz.utc),
             end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
@@ -77,7 +67,7 @@ class NdtResultEncoderTest(unittest.TestCase):
         self.assertJsonEqual(encoded_expected, encoded_actual)
 
     def test_encodes_correctly_when_result_includes_one_error(self):
-        result = create_ndt_result(
+        result = results.NdtResult(
             start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
                                          pytz.utc),
             end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
@@ -85,10 +75,9 @@ class NdtResultEncoderTest(unittest.TestCase):
             client='mock_client',
             client_version='mock_client_version',
             os='mock_os',
-            os_version='mock_os_version')
-        result.errors = [results.TestError(
-            'mock error message 1',
-            datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc))]
+            os_version='mock_os_version',
+            errors=[results.TestError('mock error message 1', datetime.datetime(
+                2016, 2, 26, 15, 53, 29, 123456, pytz.utc))])
         encoded_expected = """
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
@@ -118,7 +107,7 @@ class NdtResultEncoderTest(unittest.TestCase):
         self.assertJsonEqual(encoded_expected, encoded_actual)
 
     def test_encodes_correctly_when_result_includes_two_errors(self):
-        result = create_ndt_result(
+        result = results.NdtResult(
             start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
                                          pytz.utc),
             end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
@@ -126,15 +115,13 @@ class NdtResultEncoderTest(unittest.TestCase):
             client='mock_client',
             client_version='mock_client_version',
             os='mock_os',
-            os_version='mock_os_version')
-        result.errors = [
-            results.TestError(
-                'mock error message 1',
-                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc)),
-            results.TestError(
-                'mock error message 2',
-                datetime.datetime(2016, 2, 26, 15, 53, 29, 654321, pytz.utc))
-        ]
+            os_version='mock_os_version',
+            errors=[
+                results.TestError('mock error message 1', datetime.datetime(
+                    2016, 2, 26, 15, 53, 29, 123456, pytz.utc)),
+                results.TestError('mock error message 2', datetime.datetime(
+                    2016, 2, 26, 15, 53, 29, 654321, pytz.utc))
+            ])
         encoded_expected = """
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
@@ -168,7 +155,7 @@ class NdtResultEncoderTest(unittest.TestCase):
         self.assertJsonEqual(encoded_expected, encoded_actual)
 
     def test_encodes_fully_populated_result_correctly(self):
-        result = create_ndt_result(
+        result = results.NdtResult(
             start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
                                          pytz.utc),
             end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
@@ -176,27 +163,26 @@ class NdtResultEncoderTest(unittest.TestCase):
             client='mock_client',
             client_version='mock_client_version',
             os='mock_os',
-            os_version='mock_os_version')
-        result.c2s_result = results.NdtSingleTestResult(
-            start_time=datetime.datetime(2016, 2, 26, 15, 51, 24, 123456,
-                                         pytz.utc),
-            end_time=datetime.datetime(2016, 2, 26, 15, 51, 34, 123456,
-                                       pytz.utc),
-            throughput=10.127)
-        result.s2c_result = results.NdtSingleTestResult(
-            start_time=datetime.datetime(2016, 2, 26, 15, 51, 35, 123456,
-                                         pytz.utc),
-            end_time=datetime.datetime(2016, 2, 26, 15, 51, 45, 123456,
-                                       pytz.utc),
-            throughput=98.235)
-        result.latency = 23.8
-        result.browser = 'mock_browser'
-        result.browser_version = 'mock_browser_version'
-        result.errors = [
-            results.TestError(
-                'mock error message 1',
-                datetime.datetime(2016, 2, 26, 15, 53, 29, 123456, pytz.utc))
-        ]
+            os_version='mock_os_version',
+            c2s_result=results.NdtSingleTestResult(start_time=datetime.datetime(
+                2016, 2, 26, 15, 51, 24, 123456, pytz.utc),
+                                                   end_time=datetime.datetime(
+                                                       2016, 2, 26, 15, 51, 34,
+                                                       123456, pytz.utc),
+                                                   throughput=10.127),
+            s2c_result=results.NdtSingleTestResult(start_time=datetime.datetime(
+                2016, 2, 26, 15, 51, 35, 123456, pytz.utc),
+                                                   end_time=datetime.datetime(
+                                                       2016, 2, 26, 15, 51, 45,
+                                                       123456, pytz.utc),
+                                                   throughput=98.235),
+            latency=23.8,
+            browser='mock_browser',
+            browser_version='mock_browser_version',
+            errors=[
+                results.TestError('mock error message 1', datetime.datetime(
+                    2016, 2, 26, 15, 53, 29, 123456, pytz.utc))
+            ])
         encoded_expected = """
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
@@ -226,7 +212,7 @@ class NdtResultEncoderTest(unittest.TestCase):
         self.assertJsonEqual(encoded_expected, encoded_actual)
 
     def test_encodes_correctly_when_c2s_result_is_missing(self):
-        result = create_ndt_result(
+        result = results.NdtResult(
             start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
                                          pytz.utc),
             end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
@@ -234,14 +220,14 @@ class NdtResultEncoderTest(unittest.TestCase):
             client='mock_client',
             client_version='mock_client_version',
             os='mock_os',
-            os_version='mock_os_version')
-        result.s2c_result = results.NdtSingleTestResult(
-            start_time=datetime.datetime(2016, 2, 26, 15, 51, 35, 123456,
-                                         pytz.utc),
-            end_time=datetime.datetime(2016, 2, 26, 15, 51, 45, 123456,
-                                       pytz.utc),
-            throughput=98.235)
-        result.latency = 23.8
+            os_version='mock_os_version',
+            s2c_result=results.NdtSingleTestResult(start_time=datetime.datetime(
+                2016, 2, 26, 15, 51, 35, 123456, pytz.utc),
+                                                   end_time=datetime.datetime(
+                                                       2016, 2, 26, 15, 51, 45,
+                                                       123456, pytz.utc),
+                                                   throughput=98.235),
+            latency=23.8)
         encoded_expected = """
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
@@ -266,7 +252,7 @@ class NdtResultEncoderTest(unittest.TestCase):
         self.assertJsonEqual(encoded_expected, encoded_actual)
 
     def test_encodes_correctly_when_s2c_result_is_missing(self):
-        result = create_ndt_result(
+        result = results.NdtResult(
             start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
                                          pytz.utc),
             end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
@@ -274,14 +260,14 @@ class NdtResultEncoderTest(unittest.TestCase):
             client='mock_client',
             client_version='mock_client_version',
             os='mock_os',
-            os_version='mock_os_version')
-        result.c2s_result = results.NdtSingleTestResult(
-            start_time=datetime.datetime(2016, 2, 26, 15, 51, 24, 123456,
-                                         pytz.utc),
-            end_time=datetime.datetime(2016, 2, 26, 15, 51, 34, 123456,
-                                       pytz.utc),
-            throughput=10.127)
-        result.latency = 23.8
+            os_version='mock_os_version',
+            c2s_result=results.NdtSingleTestResult(start_time=datetime.datetime(
+                2016, 2, 26, 15, 51, 24, 123456, pytz.utc),
+                                                   end_time=datetime.datetime(
+                                                       2016, 2, 26, 15, 51, 34,
+                                                       123456, pytz.utc),
+                                                   throughput=10.127),
+            latency=23.8)
         encoded_expected = """
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
@@ -306,7 +292,7 @@ class NdtResultEncoderTest(unittest.TestCase):
         self.assertJsonEqual(encoded_expected, encoded_actual)
 
     def test_encodes_correctly_when_latency_is_missing(self):
-        result = create_ndt_result(
+        result = results.NdtResult(
             start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
                                          pytz.utc),
             end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
@@ -314,19 +300,19 @@ class NdtResultEncoderTest(unittest.TestCase):
             client='mock_client',
             client_version='mock_client_version',
             os='mock_os',
-            os_version='mock_os_version')
-        result.c2s_result = results.NdtSingleTestResult(
-            start_time=datetime.datetime(2016, 2, 26, 15, 51, 24, 123456,
-                                         pytz.utc),
-            end_time=datetime.datetime(2016, 2, 26, 15, 51, 34, 123456,
-                                       pytz.utc),
-            throughput=10.127)
-        result.s2c_result = results.NdtSingleTestResult(
-            start_time=datetime.datetime(2016, 2, 26, 15, 51, 35, 123456,
-                                         pytz.utc),
-            end_time=datetime.datetime(2016, 2, 26, 15, 51, 45, 123456,
-                                       pytz.utc),
-            throughput=98.235)
+            os_version='mock_os_version',
+            c2s_result=results.NdtSingleTestResult(start_time=datetime.datetime(
+                2016, 2, 26, 15, 51, 24, 123456, pytz.utc),
+                                                   end_time=datetime.datetime(
+                                                       2016, 2, 26, 15, 51, 34,
+                                                       123456, pytz.utc),
+                                                   throughput=10.127),
+            s2c_result=results.NdtSingleTestResult(start_time=datetime.datetime(
+                2016, 2, 26, 15, 51, 35, 123456, pytz.utc),
+                                                   end_time=datetime.datetime(
+                                                       2016, 2, 26, 15, 51, 45,
+                                                       123456, pytz.utc),
+                                                   throughput=98.235))
         encoded_expected = """
 {
     "start_time": "2016-02-26T15:51:23.452234Z",
@@ -352,7 +338,7 @@ class NdtResultEncoderTest(unittest.TestCase):
 
     def test_encodes_zero_valued_metrics(self):
         """Explicit zeroes should be encoded as zeroes, not nulls."""
-        result = create_ndt_result(
+        result = results.NdtResult(
             start_time=datetime.datetime(2016, 2, 26, 15, 51, 23, 452234,
                                          pytz.utc),
             end_time=datetime.datetime(2016, 2, 26, 15, 59, 33, 284345,
@@ -360,20 +346,20 @@ class NdtResultEncoderTest(unittest.TestCase):
             client='mock_client',
             client_version='mock_client_version',
             os='mock_os',
-            os_version='mock_os_version')
-        result.c2s_result = results.NdtSingleTestResult(
-            start_time=datetime.datetime(2016, 2, 26, 15, 51, 24, 123456,
-                                         pytz.utc),
-            end_time=datetime.datetime(2016, 2, 26, 15, 51, 34, 123456,
-                                       pytz.utc),
-            throughput=0.0)
-        result.s2c_result = results.NdtSingleTestResult(
-            start_time=datetime.datetime(2016, 2, 26, 15, 51, 35, 123456,
-                                         pytz.utc),
-            end_time=datetime.datetime(2016, 2, 26, 15, 51, 45, 123456,
-                                       pytz.utc),
-            throughput=0.0)
-        result.latency = 0.0
+            os_version='mock_os_version',
+            c2s_result=results.NdtSingleTestResult(start_time=datetime.datetime(
+                2016, 2, 26, 15, 51, 24, 123456, pytz.utc),
+                                                   end_time=datetime.datetime(
+                                                       2016, 2, 26, 15, 51, 34,
+                                                       123456, pytz.utc),
+                                                   throughput=0.0),
+            s2c_result=results.NdtSingleTestResult(start_time=datetime.datetime(
+                2016, 2, 26, 15, 51, 35, 123456, pytz.utc),
+                                                   end_time=datetime.datetime(
+                                                       2016, 2, 26, 15, 51, 45,
+                                                       123456, pytz.utc),
+                                                   throughput=0.0),
+            latency=0.0)
         encoded_expected = """
 {
     "start_time": "2016-02-26T15:51:23.452234Z",


### PR DESCRIPTION
Adds a JSON decoder so we can decode test results. Also adjusts the semantics
of the NdtResult & friends classes so they print better debug information
and support equality comparisons.

The client wrapper will not likely use this decoder directly, but it's
implemented here because consumers will need a way of decoding the JSON
output that the client wrapper produces and it seems easiest to have it
implemented once here rather than expect consumers to figure out how to
decode the JSON properly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/33)
<!-- Reviewable:end -->
