### PR TITLE
Adding a fake mlab-ns server implementation

### DIFF
--- a/client_wrapper/fake_mlabns.py
+++ b/client_wrapper/fake_mlabns.py
@@ -1,0 +1,75 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import BaseHTTPServer
+
+
+class FakeMLabNsServer(BaseHTTPServer.HTTPServer):
+    """A fake implementation of mlab-ns that returns a specified NDT server.
+
+    A fake implementation of mlab-ns that returns a static HTTP response to
+    every GET request. The response specifies a caller-defined FQDN. This is
+    intended for testing NDT clients that have mlab-ns logic baked in, so if we
+    can redirect the call to this fake mlab-ns server, we can control the NDT
+    server that the client connects to.
+
+    The HTTP server listens on all available interfaces and chooses a random
+    available TCP port to listen on.
+
+    Details on the mlab-ns protocol are available at: http://goo.gl/48S22
+
+    Attributes:
+        server_fqdn: FQDN of M-Lab server to specify in mlab-ns response.
+        port: Local port that server is listening on.
+    """
+
+    def __init__(self, server_fqdn):
+        BaseHTTPServer.HTTPServer.__init__(self, ('', 0), _FakeMLabNsHandler)
+        self._port = self.server_address[1]
+        self._server_fqdn = server_fqdn
+
+    @property
+    def server_fqdn(self):
+        return self._server_fqdn
+
+    @property
+    def port(self):
+        return self._port
+
+
+class _FakeMLabNsHandler(BaseHTTPServer.BaseHTTPRequestHandler):
+
+    def do_GET(self):
+        """Send an mlab-ns response to all GET requests.
+
+        Send an mlab-ns style JSON response to any GET requests. All fields of
+        the response are hardcoded, static values except for the 'fqdn' field,
+        which is set based on the hosting server's server_fqdn field.
+        """
+        self.send_response(200)
+        self.send_header('Content-type', 'application/json')
+        self.end_headers()
+        response = {
+            'ip': ['1.2.3.4'],
+            'country': 'US',
+            'city': 'Washington_DC',
+            'fqdn': self.server.server_fqdn,
+            'site': 'iad0t'
+        }
+        self.wfile.write(json.dumps(response))
+
+    def log_message(self, unused_format, *args):
+        """Silence console output."""
+        pass

--- a/tests/test_fake_mlabns.py
+++ b/tests/test_fake_mlabns.py
@@ -1,0 +1,49 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import json
+import threading
+import unittest
+import urllib2
+
+from client_wrapper import fake_mlabns
+
+
+class FakeMLabNsServerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.server = None
+
+    def tearDown(self):
+        if self.server:
+            self.server.shutdown()
+
+    def assertJsonEqual(self, expected, actual):
+        self.assertDictEqual(json.loads(expected), json.loads(actual))
+
+    def test_server_returns_correct_fqdn(self):
+        self.server = fake_mlabns.FakeMLabNsServer('ndt.mock-server.com')
+        threading.Thread(target=self.server.serve_forever).start()
+        response_actual = urllib2.urlopen('http://127.0.0.1:%d/ndt_ssl' %
+                                          self.server.port).read()
+        response_expected = """{
+            "fqdn": "ndt.mock-server.com",
+            "ip": ["1.2.3.4"],
+            "site": "iad0t",
+            "city": "Washington_DC",
+            "country": "US"
+            }"""
+
+        self.assertJsonEqual(response_expected, response_actual)


### PR DESCRIPTION
For clients with mlab-ns requests baked in, we need a way of gracefully
directing those clients to a server of our choosing. With a fake mlab-ns
server, we can use DNS rewrites or HTTP response modifications to sub in
our own mlab-ns server in place of mlab-ns prod, then serve the client
a custom server FQDN.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/34)
<!-- Reviewable:end -->
