### PR TITLE
Adding CORS support to fake mlab-ns server

### DIFF
--- a/client_wrapper/fake_mlabns.py
+++ b/client_wrapper/fake_mlabns.py
@@ -60,6 +60,9 @@ class _FakeMLabNsHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         """
         self.send_response(200)
         self.send_header('Content-type', 'application/json')
+        # Allow CORS requests, so that we can query the fake mlab-ns server from
+        # different origins (e.g. different localhost:port combinations).
+        self.send_header('Access-Control-Allow-Origin', '*')
         self.end_headers()
         response = {
             'ip': ['1.2.3.4'],

--- a/tests/test_fake_mlabns.py
+++ b/tests/test_fake_mlabns.py
@@ -36,8 +36,10 @@ class FakeMLabNsServerTest(unittest.TestCase):
     def test_server_returns_correct_fqdn(self):
         self.server = fake_mlabns.FakeMLabNsServer('ndt.mock-server.com')
         threading.Thread(target=self.server.serve_forever).start()
-        response_actual = urllib2.urlopen('http://127.0.0.1:%d/ndt_ssl' %
-                                          self.server.port).read()
+
+        urlopen_response = urllib2.urlopen('http://127.0.0.1:%d/ndt_ssl' %
+                                           self.server.port)
+        response_actual = urlopen_response.read()
         response_expected = """{
             "fqdn": "ndt.mock-server.com",
             "ip": ["1.2.3.4"],
@@ -47,3 +49,6 @@ class FakeMLabNsServerTest(unittest.TestCase):
             }"""
 
         self.assertJsonEqual(response_expected, response_actual)
+        headers_actual = urlopen_response.info().getheader
+        self.assertEqual('application/json', headers_actual('Content-type'))
+        self.assertEqual('*', headers_actual('Access-Control-Allow-Origin'))


### PR DESCRIPTION
CORS support is needed if, for example, we have a web server on
localhost:8123 that wants to refer the client to a fake mlab-ns server on
localhost:8321. Without a CORS header, this is considered a violation of
same origin policy and the browser would block the response.

Adding CORS better simulates real mlab-ns.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/35)
<!-- Reviewable:end -->
