### PR TITLE
Creates a replay HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,82 @@
+# NDT End-to-End Client Worker
+
 [![Build
 Status](https://travis-ci.org/m-lab/ndt-e2e-clientworker.svg?branch=master)](https://travis-ci.org/m-lab/ndt-e2e-clientworker)
 [![Coverage
 Status](https://coveralls.io/repos/m-lab/ndt-e2e-clientworker/badge.svg?branch=master&service=github)](https://coveralls.io/github/m-lab/ndt-e2e-clientworker?branch=master)
+
+## Pre-Requisites
+
+To run tests against non-Banjo clients, the user can install pre-requisites
+with:
+
+```
+pip install -r requirements.txt
+```
+
+To run tests against the Banjo NDT client, the user needs to [install
+mitmproxy](http://docs.mitmproxy.org/en/latest/install.html) and either create
+a mitmdump replay file or use an existing one. For details on creating a replay
+file, see the section below.
+
+## Creating a mitmdump HTTP Replay File
+
+For clients that are difficult to host as static files, the NDT client wrapper
+uses `mitmdump` to replay HTTP traffic to replicate the behavior of those
+clients, but without communicating with a remote server. In order to replicate
+a web application that hosts an NDT client, the user must first create a
+`mitmdump` HTTP replay file.
+
+For example, imagine that we wish to locally replicate an NDT client hosted at:
+
+  http://example.com/tests/ndt
+
+### 1. Start `mitmdump`
+
+We first run `mitmdump` as follows:
+
+```
+mitmdump \
+  --port 8123 \
+  --reverse http://example.com \
+  --no-http2 \
+  --setheader :~q:Host:example.com \
+  --wfile /tmp/example.com-output.replay
+```
+
+This runs `mitmdump` as a [reverse
+proxy](http://docs.mitmproxy.org/en/latest/features/reverseproxy.html) against
+example.com. We also rewrite the `Host:` header so that our reverse proxy
+forwards HTTP requests to the real example.com server and makes them appear
+similar to normal requests.
+
+### 2. Capture browser traffic
+
+With `mitmdump` running, open a browser and navigate to:
+
+  http://localhost:8123/tests/ndt
+
+After the NDT test is complete, end the `mitmdump` with Ctrl+C and the replay
+file will appear in the output path.
+
+### 3. Run client\_wrapper
+
+Once we have a replay file, we can run the `client_wrapper` as follows:
+
+```
+python client_wrapper/client_wrapper.py \
+  --client <client name> \
+  --browser firefox \
+  --server ndt-iupui-mlab2-nuq0t.measurement-lab.org \
+  --client_path /tmp/example.com-output.replay \
+  --output /tmp
+```
+
+### Limitations
+
+The reverse proxy only captures traffic intended for a single origin (domain +
+port pair). If the web application's NDT client relies on CORS requests to
+to multiple origins (not including mlab-ns), the `client_wrapper` NDT HTTP
+replay server will not be able to replicate the web app locally. The replay
+server does handle CORS requests to mlab-ns by creating a fake mlab-ns server
+locally.

--- a/client_wrapper/client_wrapper.py
+++ b/client_wrapper/client_wrapper.py
@@ -28,7 +28,8 @@ import os_metadata
 def main(args):
     if args.client == names.BANJO:
         fake_mlabns_server = fake_mlabns.FakeMLabNsServer(args.server)
-        print 'starting fake mlab-ns server on port %d' % fake_mlabns_server.port
+        print 'starting fake mlab-ns server on port %d' % (
+            fake_mlabns_server.port)
         with contextlib.closing(http_server.ReplayHTTPServer(
                 args.replay_port, fake_mlabns_server, args.client_path)):
             print 'replay server replaying %s on port %d' % (args.client_path,

--- a/client_wrapper/http_server.py
+++ b/client_wrapper/http_server.py
@@ -1,0 +1,131 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Defines HTTP servers for web-based NDT clients.
+
+Defines various HTTP server classes meant for hosting web-based NDT client
+implementations.
+"""
+
+import re
+import subprocess
+import threading
+
+
+class Error(Exception):
+    pass
+
+
+class MitmProxyNotInstalledError(Error):
+    """Error raised when mitmproxy seems to not be installed."""
+
+    def __init__(self):
+        super(MitmProxyNotInstalledError, self).__init__(
+            'Failed to execute mitmdump utility. Is mitmproxy installed? '
+            'http://docs.mitmproxy.org/en/stable/install.html')
+
+
+class ReplayHTTPServer(object):
+    """HTTP server that replays saved HTTP traffic to facilitate an NDT test.
+
+    This replays HTTP traffic from a mitmdump file in order to replicate a
+    remote web application that hosts a web-based NDT client.
+
+    This is a more complex NDT HTTP server host that is meant to host NDT
+    clients that cannot be represented easily with static HTML files. In
+    general, most NDT clients can be hosted with StaticHTTPServer (not yet
+    implemented) and should prefer that class to ReplayHTTPServer.
+
+    Caller is responsible for cleaning up the replay server's resources by
+    calling close() on the instance.
+    """
+
+    def __init__(self, listen_port, mlabns_server, replay_filename):
+        """Create a new ReplayHTTPServer instance and listen for connections.
+
+        Args:
+            listen_port: The local port on which to listen on to replay traffic.
+                This will allow HTTP clients to connect to this port as if were
+                a normal web server.
+            mlabns_server: An instance of FakeMLabNsServer to use as the fake
+                mlab-ns server for traffic replays.
+            replay_filename: Path to filename that contains a mitmdump/mitmproxy
+                traffic capture file. The replay server will use this file to
+                replay HTTP traffic.
+        """
+        self._listen_port = listen_port
+        self._mlabns_server = mlabns_server
+        self._replay_filename = replay_filename
+        self._mlabns_thread = None
+        self._server_proc = None
+        self._start_async()
+
+    def _start_async(self):
+        """Start the replay HTTP traffic server asynchronously.
+
+        Starts the replay HTTP server in a separate process and the fake mlab-ns
+        server in a separate thread.
+
+        Note that it is in theory possible to launch mitmdump in pure Python
+        using the mitmproxy package. We choose not to because those APIs are
+        not documented, whereas the command line parameters are. We therefore
+        run mitmdump in a separate process even though it's a bit uglier to do
+        so.
+        """
+        cmd_params = ['mitmdump']
+        # Suppress warning about lack of HTTP/2 support. We don't need HTTP/2.
+        cmd_params.append('--no-http2')
+        # Allow server to re-use responses for particular requests (default is
+        # to pop responses from the replay queue after the first matching
+        # request).
+        cmd_params.append('--no-pop')
+        # Set up local port to listen for connections.
+        cmd_params.append('--port=%d' % self._listen_port)
+        # Run in reverse proxy mode, but the original hostname no longer
+        # matters, so we set it to a garbage value and signal to ignore the
+        # hostname.
+        cmd_params.append('--reverse=http://ignored.ignored')
+        cmd_params.append('--replay-ignore-host')
+        # Specify the mitmdump file to replay.
+        cmd_params.append('--server-replay=%s' % self._replay_filename)
+        # Replace references to production mlab-ns in HTTP traffic with a
+        # our own fake mlab-ns server.
+        mlabns_original = re.escape('mlab-ns.appspot.com')
+        mlabns_replaced = re.escape('localhost:%d' % self._mlabns_server.port)
+        cmd_params.append('--replace=/~s/%s/%s' % (mlabns_original,
+                                                   mlabns_replaced))
+
+        # Start the fake mlab-ns server in a background thread.
+        self._mlabns_thread = threading.Thread(
+            target=self._mlabns_server.serve_forever)
+        self._mlabns_thread.start()
+
+        # Launch mitmdump in a subprocess.
+        try:
+            self._server_proc = subprocess.Popen(cmd_params,
+                                                 stdout=subprocess.PIPE)
+        except OSError:
+            raise MitmProxyNotInstalledError()
+
+    def close(self):
+        """Close the replay server by terminating all background workers.
+
+        Terminates all background processes and threads to shut down the replay
+        server. Caller is responsible for calling this method when it is
+        finished with a ReplayHTTPServer instance.
+        """
+        if self._server_proc:
+            self._server_proc.kill()
+        if self._mlabns_thread:
+            self._mlabns_server.shutdown()
+            self._mlabns_thread.join()

--- a/client_wrapper/names.py
+++ b/client_wrapper/names.py
@@ -19,6 +19,7 @@ testing system to identify NDT clients, browsers, and operating systems.
 
 # NDT client shortnames
 NDT_HTML5 = 'ndt_js'  # Official NDT HTML5 reference client
+BANJO = 'banjo'
 
 # Browser name constants
 FIREFOX = 'firefox'

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -1,0 +1,83 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import contextlib
+import subprocess
+import unittest
+
+import mock
+
+from client_wrapper import fake_mlabns
+from client_wrapper import http_server
+
+MOCK_LISTEN_PORT = 8123
+MOCK_MLABNS_PORT = 8321
+MOCK_REPLAY_FILENAME = 'mock-file.replay'
+
+
+class ReplayHTTPServerTest(unittest.TestCase):
+
+    def setUp(self):
+        # Mock out calls to subprocess.Popen.
+        subprocess_popen_patch = mock.patch.object(subprocess,
+                                                   'Popen',
+                                                   autospec=True)
+        self.addCleanup(subprocess_popen_patch.stop)
+        subprocess_popen_patch.start()
+
+        self.mock_mlabns_server = mock.Mock(spec=fake_mlabns.FakeMLabNsServer,
+                                            port=MOCK_MLABNS_PORT)
+
+    def make_server(self):
+        """Convenience method to create server under test."""
+        return http_server.ReplayHTTPServer(
+            MOCK_LISTEN_PORT, self.mock_mlabns_server, MOCK_REPLAY_FILENAME)
+
+    def test_creating_server_creates_correct_threads_and_processes(self):
+        mock_mitmdump_proc = mock.Mock()
+        subprocess.Popen.return_value = mock_mitmdump_proc
+
+        with contextlib.closing(self.make_server()):
+            # Verify that mitmdump was spawned correctly
+            subprocess.Popen.assert_called_once_with(
+                ['mitmdump', '--no-http2', '--no-pop', '--port=8123',
+                 '--reverse=http://ignored.ignored', '--replay-ignore-host',
+                 '--server-replay=mock-file.replay',
+                 '--replace=/~s/mlab\\-ns\\.appspot\\.com/localhost\\:8321'],
+                stdout=subprocess.PIPE)
+            # Verify that mlab-ns server is serving
+            self.assertTrue(self.mock_mlabns_server.serve_forever.called)
+            # Verify that the internal workers are not killed before we exit
+            # the context handler.
+            self.assertFalse(mock_mitmdump_proc.kill.called)
+            self.assertFalse(self.mock_mlabns_server.shutdown.called)
+
+        # After exiting the context handler, the internal workers should be
+        # terminated.
+        self.assertTrue(mock_mitmdump_proc.kill.called)
+        self.assertTrue(self.mock_mlabns_server.shutdown.called)
+
+    def test_raises_error_when_mitmproxy_is_not_installed(self):
+        """If we can't execute mitmproxy, show a helpful error."""
+        # Cause a mock error when spawning the mitmproxy process.
+        subprocess.Popen.side_effect = OSError('mock OSError')
+
+        with self.assertRaises(http_server.MitmProxyNotInstalledError):
+            with contextlib.closing(self.make_server()):
+                pass
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Creates a replay HTTP server meant for replaying HTTP traffic. This is
useful for NDT clients that are hosted in complex web applications, where
it is not trivial to extract the NDT test into simple static files we could
host with something like SimpleHTTPServer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/36)
<!-- Reviewable:end -->
