### PR TITLE
Allow pre-commit example run multiple times

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -1,4 +1,4 @@
 To enable client_wrapper's git hooks in your git repo, run the following from
 the repo root:
 
-`rm -rf .git/hooks/ && ln -s -f ../hooks .git/`
+`rm -rf .git/hooks && ln -s -f ../hooks .git/`


### PR DESCRIPTION
This small change to allows the pre-commit hook example command to run multiple times. Without this fix, the `rm -rf` will delete the files under the hooks directory. With this fix, the symbolic link is removed instead of the files in the hooks directory.