### PR TITLE
Refactoring create_browser function to common module

### DIFF
--- a/client_wrapper/browser_client_common.py
+++ b/client_wrapper/browser_client_common.py
@@ -1,0 +1,38 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from selenium import webdriver
+
+import names
+
+
+def create_browser(browser):
+    """Creates a Selenium-controlled web browser.
+
+    Args:
+        browser: Can be one of 'firefox', 'chrome', 'edge', or 'safari'
+
+    Returns:
+        An instance of a Selenium webdriver browser class corresponding to
+        the specified browser.
+    """
+    if browser == names.FIREFOX:
+        return webdriver.Firefox()
+    elif browser == names.CHROME:
+        return webdriver.Chrome()
+    elif browser == names.EDGE:
+        return webdriver.Edge()
+    elif browser == names.SAFARI:
+        return webdriver.Safari()
+    raise ValueError('Invalid browser specified: %s' % browser)

--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -17,11 +17,11 @@ import contextlib
 import datetime
 
 import pytz
-from selenium import webdriver
 from selenium.webdriver.support import ui
 from selenium.webdriver.support import expected_conditions
 from selenium.common import exceptions
 
+import browser_client_common
 import names
 import results
 
@@ -57,7 +57,8 @@ class NdtHtml5SeleniumDriver(object):
         result.client = names.NDT_HTML5
         result.start_time = datetime.datetime.now(pytz.utc)
 
-        with contextlib.closing(_create_browser(self._browser)) as driver:
+        with contextlib.closing(browser_client_common.create_browser(
+                self._browser)) as driver:
             result.browser = self._browser
             result.browser_version = driver.capabilities['version']
 
@@ -65,27 +66,6 @@ class NdtHtml5SeleniumDriver(object):
 
         result.end_time = datetime.datetime.now(pytz.utc)
         return result
-
-
-def _create_browser(browser):
-    """Creates browser for an NDT test.
-
-    Args:
-        browser: Can be one of 'firefox', 'chrome', 'edge', or 'safari'
-
-    Returns:
-        An instance of a Selenium webdriver browser class corresponding to
-        the specified browser.
-    """
-    if browser == names.FIREFOX:
-        return webdriver.Firefox()
-    elif browser == names.CHROME:
-        return webdriver.Chrome()
-    elif browser == names.EDGE:
-        return webdriver.Edge()
-    elif browser == names.SAFARI:
-        return webdriver.Safari()
-    raise ValueError('Invalid browser specified: %s' % browser)
 
 
 def _load_url(driver, url, result):

--- a/tests/test_browser_client_common.py
+++ b/tests/test_browser_client_common.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 import unittest
 
 import mock
-from selenium import webdriver
 
 from client_wrapper import browser_client_common
 from client_wrapper import names
@@ -24,7 +23,7 @@ from client_wrapper import names
 class CreateBrowserTest(unittest.TestCase):
     """Tests for create_browser function."""
 
-    @mock.patch.object(webdriver, 'Firefox')
+    @mock.patch.object(browser_client_common.webdriver, 'Firefox')
     def test_create_firefox_browser_succeeds(self, mock_firefox):
         mock_firefox.return_value = 'mock firefox driver'
 
@@ -32,7 +31,7 @@ class CreateBrowserTest(unittest.TestCase):
                          browser_client_common.create_browser(names.FIREFOX))
         self.assertTrue(mock_firefox.called)
 
-    @mock.patch.object(webdriver, 'Chrome')
+    @mock.patch.object(browser_client_common.webdriver, 'Chrome')
     def test_create_chrome_browser_succeeds(self, mock_chrome):
         mock_chrome.return_value = 'mock chrome driver'
 
@@ -40,7 +39,7 @@ class CreateBrowserTest(unittest.TestCase):
                          browser_client_common.create_browser(names.CHROME))
         self.assertTrue(mock_chrome.called)
 
-    @mock.patch.object(webdriver, 'Edge')
+    @mock.patch.object(browser_client_common.webdriver, 'Edge')
     def test_create_edge_driver_succeeds(self, mock_edge):
         mock_edge.return_value = 'mock edge driver'
 
@@ -48,7 +47,7 @@ class CreateBrowserTest(unittest.TestCase):
                          browser_client_common.create_browser(names.EDGE))
         self.assertTrue(mock_edge.called)
 
-    @mock.patch.object(webdriver, 'Safari')
+    @mock.patch.object(browser_client_common.webdriver, 'Safari')
     def test_create_safari_browser_succeeds(self, mock_safari):
         mock_safari.return_value = 'mock safari driver'
 

--- a/tests/test_browser_client_common.py
+++ b/tests/test_browser_client_common.py
@@ -1,0 +1,65 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+import unittest
+
+import mock
+from selenium import webdriver
+
+from client_wrapper import browser_client_common
+from client_wrapper import names
+
+
+class CreateBrowserTest(unittest.TestCase):
+    """Tests for create_browser function."""
+
+    @mock.patch.object(webdriver, 'Firefox')
+    def test_create_firefox_browser_succeeds(self, mock_firefox):
+        mock_firefox.return_value = 'mock firefox driver'
+
+        self.assertEqual('mock firefox driver',
+                         browser_client_common.create_browser(names.FIREFOX))
+        self.assertTrue(mock_firefox.called)
+
+    @mock.patch.object(webdriver, 'Chrome')
+    def test_create_chrome_browser_succeeds(self, mock_chrome):
+        mock_chrome.return_value = 'mock chrome driver'
+
+        self.assertEqual('mock chrome driver',
+                         browser_client_common.create_browser(names.CHROME))
+        self.assertTrue(mock_chrome.called)
+
+    @mock.patch.object(webdriver, 'Edge')
+    def test_create_edge_driver_succeeds(self, mock_edge):
+        mock_edge.return_value = 'mock edge driver'
+
+        self.assertEqual('mock edge driver',
+                         browser_client_common.create_browser(names.EDGE))
+        self.assertTrue(mock_edge.called)
+
+    @mock.patch.object(webdriver, 'Safari')
+    def test_create_safari_browser_succeeds(self, mock_safari):
+        mock_safari.return_value = 'mock safari driver'
+
+        self.assertEqual('mock safari driver',
+                         browser_client_common.create_browser(names.SAFARI))
+        self.assertTrue(mock_safari.called)
+
+    def test_create_unrecognized_browser_raises_error(self):
+        with self.assertRaises(ValueError):
+            browser_client_common.create_browser('not a real browser name')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -270,7 +270,8 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
             # now().
             mocked_datetime.now.side_effect = times
 
-            # Modify the Firefox mock to increment the clock forward one call.
+            # Modify the create_browser mock to increment the clock forward one
+            # call.
             def mock_create_browser(unused_browser_name):
                 datetime.datetime.now(pytz.utc)
                 return self.mock_driver

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -18,8 +18,8 @@ import unittest
 
 import mock
 import pytz
-from selenium import webdriver
 from selenium.common import exceptions
+from client_wrapper import browser_client_common
 from client_wrapper import html5_driver
 
 
@@ -65,11 +65,12 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
 
         self.mock_driver.find_elements_by_xpath = mock_find_elements_by_xpath
 
-        firefox_patcher = mock.patch.object(webdriver, 'Firefox')
-        self.addCleanup(firefox_patcher.stop)
-        firefox_patcher.start()
+        create_browser_patcher = mock.patch.object(browser_client_common,
+                                                   'create_browser')
+        self.addCleanup(create_browser_patcher.stop)
+        create_browser_patcher.start()
 
-        webdriver.Firefox.return_value = self.mock_driver
+        browser_client_common.create_browser.return_value = self.mock_driver
 
     def assertErrorMessagesEqual(self, expected_messages, actual_errors):
         """Verifies that a list of TestErrors have the expected error messages.
@@ -270,11 +271,12 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
             mocked_datetime.now.side_effect = times
 
             # Modify the Firefox mock to increment the clock forward one call.
-            def mock_firefox():
+            def mock_create_browser(unused_browser_name):
                 datetime.datetime.now(pytz.utc)
                 return self.mock_driver
 
-            webdriver.Firefox.side_effect = mock_firefox
+            browser_client_common.create_browser.side_effect = (
+                mock_create_browser)
 
             # Modify the visibility_of mock to increment the clock forward one
             # call.

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -18,6 +18,7 @@ import unittest
 
 import mock
 import pytz
+from selenium import webdriver
 from selenium.common import exceptions
 from client_wrapper import html5_driver
 
@@ -64,11 +65,11 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
 
         self.mock_driver.find_elements_by_xpath = mock_find_elements_by_xpath
 
-        firefox_patcher = mock.patch.object(html5_driver.webdriver, 'Firefox')
+        firefox_patcher = mock.patch.object(webdriver, 'Firefox')
         self.addCleanup(firefox_patcher.stop)
         firefox_patcher.start()
 
-        html5_driver.webdriver.Firefox.return_value = self.mock_driver
+        webdriver.Firefox.return_value = self.mock_driver
 
     def assertErrorMessagesEqual(self, expected_messages, actual_errors):
         """Verifies that a list of TestErrors have the expected error messages.
@@ -130,14 +131,6 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
 
         self.assertErrorMessagesEqual(
             [html5_driver.ERROR_C2S_NEVER_STARTED], result.errors)
-
-    def test_unrecognized_browser_raises_error(self):
-        selenium_driver = html5_driver.NdtHtml5SeleniumDriver(
-            browser='not_a_browser',
-            url='http://ndt.mock-server.com:7123',
-            timeout=1)
-        with self.assertRaises(ValueError):
-            selenium_driver.perform_test()
 
     def test_results_page_displays_non_numeric_latency(self):
         self.mock_page_elements['latency'] = mock.Mock(text='Non-numeric value')
@@ -244,45 +237,6 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
         self.assertErrorMessagesEqual(
             ['Invalid throughput unit specified: banana'], result.errors)
 
-    @mock.patch.object(html5_driver.webdriver, 'Chrome')
-    def test_chrome_driver_can_be_used_for_test(self, mock_chrome):
-        mock_chrome.return_value = self.mock_driver
-        result = html5_driver.NdtHtml5SeleniumDriver(
-            browser='chrome',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
-
-        self.assertEqual(1.0, result.c2s_result.throughput)
-        self.assertEqual(2.0, result.s2c_result.throughput)
-        self.assertEqual(3.0, result.latency)
-        self.assertErrorMessagesEqual([], result.errors)
-
-    @mock.patch.object(html5_driver.webdriver, 'Edge')
-    def test_edge_driver_can_be_used_for_test(self, mock_edge):
-        mock_edge.return_value = self.mock_driver
-        result = html5_driver.NdtHtml5SeleniumDriver(
-            browser='edge',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
-
-        self.assertEqual(1.0, result.c2s_result.throughput)
-        self.assertEqual(2.0, result.s2c_result.throughput)
-        self.assertEqual(3.0, result.latency)
-        self.assertErrorMessagesEqual([], result.errors)
-
-    @mock.patch.object(html5_driver.webdriver, 'Safari')
-    def test_safari_driver_can_be_used_for_test(self, mock_safari):
-        mock_safari.return_value = self.mock_driver
-        result = html5_driver.NdtHtml5SeleniumDriver(
-            browser='safari',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
-
-        self.assertEqual(1.0, result.c2s_result.throughput)
-        self.assertEqual(2.0, result.s2c_result.throughput)
-        self.assertEqual(3.0, result.latency)
-        self.assertErrorMessagesEqual([], result.errors)
-
     def test_c2s_kbps_speed_conversion(self):
         """Test c2s speed converts from kb/s to Mb/s correctly."""
         # If c2s speed is 72 kb/s and s2c speed is 34 in the browser
@@ -320,7 +274,7 @@ class NdtHtml5SeleniumDriverTest(unittest.TestCase):
                 datetime.datetime.now(pytz.utc)
                 return self.mock_driver
 
-            html5_driver.webdriver.Firefox.side_effect = mock_firefox
+            webdriver.Firefox.side_effect = mock_firefox
 
             # Modify the visibility_of mock to increment the clock forward one
             # call.


### PR DESCRIPTION
Refactoring the create_browser function to a common module for shared
functions among browser-based NDT tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/39)
<!-- Reviewable:end -->
