### PR TITLE
Reducing impact of race condition in ReplayHTTPServer

### DIFF
--- a/client_wrapper/http_server.py
+++ b/client_wrapper/http_server.py
@@ -81,7 +81,7 @@ class ReplayHTTPServer(object):
         self._start_mitmdump_async()
 
     def _start_fake_mlabns_async(self):
-        """Start the fake mlab-ns server in a background thread
+        """Start the fake mlab-ns server in a background thread.
 
         Start the fake mlab-ns server in a background thread, but block until
         that thread begins.

--- a/client_wrapper/http_server.py
+++ b/client_wrapper/http_server.py
@@ -67,6 +67,7 @@ class ReplayHTTPServer(object):
         self._mlabns_server = mlabns_server
         self._replay_filename = replay_filename
         self._mlabns_thread = None
+        self._mlabns_serving_event = threading.Event()
         self._server_proc = None
         self._start_async()
 
@@ -75,6 +76,30 @@ class ReplayHTTPServer(object):
 
         Starts the replay HTTP server in a separate process and the fake mlab-ns
         server in a separate thread.
+        """
+        self._start_fake_mlabns_async()
+        self._start_mitmdump_async()
+
+    def _start_fake_mlabns_async(self):
+        """Start the fake mlab-ns server in a background thread
+
+        Start the fake mlab-ns server in a background thread, but block until
+        that thread begins.
+        """
+        self._mlabns_thread = threading.Thread(target=self._start_fake_mlabns)
+        self._mlabns_thread.start()
+        self._mlabns_serving_event.wait()
+
+    def _start_fake_mlabns(self):
+        # Set the serving event to indicate that fake mlab-ns server is serving.
+        # Note: There is a race condition here, as there is a delay between the
+        # time the event is set and the time the server actually begins serving.
+        # We assume that this is good enough for now.
+        self._mlabns_serving_event.set()
+        self._mlabns_server.serve_forever()
+
+    def _start_mitmdump_async(self):
+        """Starts a mitmdump process as a reverse proxy to replay traffic.
 
         Note that it is in theory possible to launch mitmdump in pure Python
         using the mitmproxy package. We choose not to because those APIs are
@@ -104,11 +129,6 @@ class ReplayHTTPServer(object):
         mlabns_replaced = re.escape('localhost:%d' % self._mlabns_server.port)
         cmd_params.append('--replace=/~s/%s/%s' % (mlabns_original,
                                                    mlabns_replaced))
-
-        # Start the fake mlab-ns server in a background thread.
-        self._mlabns_thread = threading.Thread(
-            target=self._mlabns_server.serve_forever)
-        self._mlabns_thread.start()
 
         # Launch mitmdump in a subprocess.
         try:


### PR DESCRIPTION
There is a race condition in ReplayHTTPServer in that one thread needs to
execute serve_forever, which blocks forever, but other threads need to know
that it has started serving.

I wasn't able to figure out a way to eliminate the race condition
completely, but I believe this reduces the impact to the point that it is
fixed for practical purposes. In practice, there will be a delay of several
milliseconds between the client making an HTTP request to the replay server
then making another HTTP request to the fake mlab-ns server.

This is mainly to fix flakiness in unit tests (issue #43), which it appears
to fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/44)
<!-- Reviewable:end -->
