### PR TITLE
Adding error handling for when Start Test button does not appear

### DIFF
--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -27,6 +27,8 @@ import results
 ERROR_C2S_NEVER_STARTED = 'Timed out waiting for c2s test to begin.'
 ERROR_S2C_NEVER_STARTED = 'Timed out waiting for c2s test to begin.'
 ERROR_S2C_NEVER_ENDED = 'Timed out waiting for c2s test to end.'
+ERROR_START_BUTTON_NOT_IN_DOM = '"Start Test" button does not appear in DOM.'
+ERROR_TIMED_OUT_WAITING_FOR_START_BUTTON = 'Timed out waiting for "Start Test" button to appear.'
 
 
 class NdtHtml5SeleniumDriver(object):
@@ -79,7 +81,9 @@ def _complete_ui_flow(driver, url, timeout, result):
     if not browser_client_common.load_url(driver, url, result.errors):
         return
 
-    _click_start_button(driver)
+    _click_websocket_button(driver)
+    if not _click_start_button(driver, timeout, result.errors):
+        return
     result.c2s_result = results.NdtSingleTestResult()
     result.s2c_result = results.NdtSingleTestResult()
 
@@ -105,16 +109,36 @@ def _complete_ui_flow(driver, url, timeout, result):
     _populate_metric_values(result, driver)
 
 
-def _click_start_button(driver):
+def _click_websocket_button(driver):
+    # TODO(mtlynch): Handle case when element is not found.
+    driver.find_element_by_id('websocketButton').click()
+
+
+def _click_start_button(driver, timeout, errors):
     """Clicks the "Start Test" button in the web UI.
 
     Args:
         driver: An instance of a Selenium webdriver browser class.
+        timeout: Maximum time (in seconds) to wait for an element to appear in
+            the flow.
+        errors: An errors list.
+
+    Returns:
+        True if the "Start Test" button could be successfully located
+        and clicked.
     """
-    driver.find_element_by_id('websocketButton').click()
-    # TODO(mtlynch): Handle case when element is not found.
-    browser_client_common.find_element_containing_text(driver,
-                                                       'Start Test').click()
+    start_button = browser_client_common.find_element_containing_text(
+        driver, 'Start Test')
+    if not start_button:
+        errors.append(results.TestError(ERROR_START_BUTTON_NOT_IN_DOM))
+        return False
+    if not browser_client_common.wait_until_element_is_visible(
+            driver, start_button, timeout):
+        errors.append(results.TestError(
+            ERROR_TIMED_OUT_WAITING_FOR_START_BUTTON))
+        return False
+    start_button.click()
+    return True
 
 
 def _wait_for_c2s_test_to_start(driver, timeout):

--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -28,7 +28,8 @@ ERROR_C2S_NEVER_STARTED = 'Timed out waiting for c2s test to begin.'
 ERROR_S2C_NEVER_STARTED = 'Timed out waiting for c2s test to begin.'
 ERROR_S2C_NEVER_ENDED = 'Timed out waiting for c2s test to end.'
 ERROR_START_BUTTON_NOT_IN_DOM = '"Start Test" button does not appear in DOM.'
-ERROR_TIMED_OUT_WAITING_FOR_START_BUTTON = 'Timed out waiting for "Start Test" button to appear.'
+ERROR_TIMED_OUT_WAITING_FOR_START_BUTTON = (
+    'Timed out waiting for "Start Test" button to appear.')
 
 
 class NdtHtml5SeleniumDriver(object):

--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -83,6 +83,7 @@ def _complete_ui_flow(driver, url, timeout, result):
         return
 
     _click_websocket_button(driver)
+    # If we can't click the start button, nothing left to do, so bail out.
     if not _click_start_button(driver, timeout, result.errors):
         return
     result.c2s_result = results.NdtSingleTestResult()

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -98,9 +98,11 @@ class NdtHtml5SeleniumDriverTest(ndt_client_test.NdtClientTest):
             [html5_driver.ERROR_START_BUTTON_NOT_IN_DOM], result.errors)
 
     def test_fails_gracefully_if_wait_for_start_button_times_out(self):
-        # Make the "Start Test" button visible, but others time out.
+        # Simulate a webdriver timeout when waiting for any element to appear,
+        # including the "Start Test" button.
         html5_driver.browser_client_common.wait_until_element_is_visible.return_value = (
             False)
+
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
             url='http://ndt.mock-server.com:7123/',

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -17,6 +17,7 @@ import unittest
 
 import mock
 import pytz
+
 from client_wrapper import browser_client_common
 from client_wrapper import html5_driver
 from tests import ndt_client_test
@@ -82,10 +83,42 @@ class NdtHtml5SeleniumDriverTest(ndt_client_test.NdtClientTest):
         self.assertEqual(3.0, result.latency)
         self.assertErrorMessagesEqual([], result.errors)
 
-    def test_test_in_progress_timeout_yields_timeout_errors(self):
-        """If each test times out, expect an error for each timeout."""
+    def test_fails_gracefully_when_start_button_not_in_dom(self):
+        self.mock_elements_by_text['Start Test'] = None
+
+        result = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1).perform_test()
+
+        self.assertIsNone(result.c2s_result.throughput)
+        self.assertIsNone(result.s2c_result.throughput)
+        self.assertIsNone(result.latency)
+        self.assertErrorMessagesEqual(
+            [html5_driver.ERROR_START_BUTTON_NOT_IN_DOM], result.errors)
+
+    def test_fails_gracefully_if_wait_for_start_button_times_out(self):
+        # Make the "Start Test" button visible, but others time out.
         html5_driver.browser_client_common.wait_until_element_is_visible.return_value = (
             False)
+        result = html5_driver.NdtHtml5SeleniumDriver(
+            browser='firefox',
+            url='http://ndt.mock-server.com:7123/',
+            timeout=1).perform_test()
+
+        self.assertIsNone(result.c2s_result.throughput)
+        self.assertIsNone(result.s2c_result.throughput)
+        self.assertIsNone(result.latency)
+        self.assertErrorMessagesEqual(
+            [html5_driver.ERROR_TIMED_OUT_WAITING_FOR_START_BUTTON],
+            result.errors)
+
+    def test_test_in_progress_timeout_yields_timeout_errors(self):
+        """If each test times out, expect an error for each timeout."""
+        # Make the "Start Test" button visible, but others time out.
+        html5_driver.browser_client_common.wait_until_element_is_visible.side_effect = [
+            True, False, False, False
+        ]
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
             url='http://ndt.mock-server.com:7123/',
@@ -99,7 +132,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_test.NdtClientTest):
     def test_c2s_start_timeout_yields_errors(self):
         """If waiting for just c2s start times out, expect just one error."""
         html5_driver.browser_client_common.wait_until_element_is_visible.side_effect = [
-            False, True, True
+            True, False, True, True
         ]
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
@@ -236,7 +269,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_test.NdtClientTest):
     def test_ndt_result_increments_time_correctly(self):
         # Create a list of mock times to be returned by datetime.now().
         times = []
-        for i in range(10):
+        for i in range(11):
             times.append(datetime.datetime(2016, 1, 1, 0, 0, i))
 
         with mock.patch.object(html5_driver.datetime,
@@ -273,15 +306,16 @@ class NdtHtml5SeleniumDriverTest(ndt_client_test.NdtClientTest):
         # Verify the recorded times matches the expected sequence.
         self.assertEqual(times[0], result.start_time)
         # times[1] is the call from mock_firefox
-        # times[2] is the check for visibility of c2s test start
-        self.assertEqual(times[3], result.c2s_result.start_time)
-        # times[4] is the check for visibility of s2c test start (start of s2c
+        # times[2] is the check for visibility of "Start Test" button
+        # times[3] is the check for visibility of c2s test start
+        self.assertEqual(times[4], result.c2s_result.start_time)
+        # times[5] is the check for visibility of s2c test start (start of s2c
         #   marks the end of c2s)
-        self.assertEqual(times[5], result.c2s_result.end_time)
-        self.assertEqual(times[6], result.s2c_result.start_time)
-        # times[7] is the check for visibility of results page
-        self.assertEqual(times[8], result.s2c_result.end_time)
-        self.assertEqual(times[9], result.end_time)
+        self.assertEqual(times[6], result.c2s_result.end_time)
+        self.assertEqual(times[7], result.s2c_result.start_time)
+        # times[8] is the check for visibility of results page
+        self.assertEqual(times[9], result.s2c_result.end_time)
+        self.assertEqual(times[10], result.end_time)
 
 
 if __name__ == '__main__':

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -119,7 +119,10 @@ class NdtHtml5SeleniumDriverTest(ndt_client_test.NdtClientTest):
         """If each test times out, expect an error for each timeout."""
         # Make the "Start Test" button visible, but others time out.
         html5_driver.browser_client_common.wait_until_element_is_visible.side_effect = [
-            True, False, False, False
+            True,  # "Start Test" button
+            False,  # Upload speed label
+            False,  # Download speed label
+            False,  # Results div
         ]
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
@@ -134,7 +137,10 @@ class NdtHtml5SeleniumDriverTest(ndt_client_test.NdtClientTest):
     def test_c2s_start_timeout_yields_errors(self):
         """If waiting for just c2s start times out, expect just one error."""
         html5_driver.browser_client_common.wait_until_element_is_visible.side_effect = [
-            True, False, True, True
+            True,  # "Start Test" button
+            False,  # Upload speed label
+            True,  # Download speed label
+            True,  # Results div
         ]
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',


### PR DESCRIPTION
Adds graceful error handling for the case where the "Start Test"
button either is not in the DOM at all or we time out waiting
for it to appear.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/45)
<!-- Reviewable:end -->
