### PR TITLE
Adding a partial implementation of the Banjo driver

### DIFF
--- a/client_wrapper/banjo_driver.py
+++ b/client_wrapper/banjo_driver.py
@@ -1,0 +1,97 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+import contextlib
+import datetime
+
+import pytz
+
+import browser_client_common
+import names
+import results
+
+ERROR_FAILED_TO_LOCATE_RUN_TEST_BUTTON = 'Failed to locate "Run Speed Test" button.'
+
+
+class BanjoDriver(object):
+
+    def __init__(self, browser, url):
+        """Creates a Banjo client driver for the given URL and browser.
+
+        Args:
+            url: The URL of an NDT server to test against.
+            browser: Can be one of 'firefox', 'chrome', 'edge', or 'safari'.
+        """
+        self._browser = browser
+        self._url = url
+
+    def perform_test(self):
+        """Performs a full NDT test (both s2c and c2s) with the Banjo client.
+
+        Returns:
+            A populated NdtResult object.
+        """
+        result = results.NdtResult(client=names.BANJO,
+                                   start_time=datetime.datetime.now(pytz.utc))
+
+        with contextlib.closing(browser_client_common.create_browser(
+                self._browser)) as driver:
+            result.browser = self._browser
+            result.browser_version = driver.capabilities['version']
+
+            if not browser_client_common.load_url(driver, self._url,
+                                                  result.errors):
+                return
+
+            _BanjoUiFlowWrapper(driver, self._url, result).complete_ui_flow()
+
+        result.end_time = datetime.datetime.now(pytz.utc)
+        return result
+
+
+class _BanjoUiFlowWrapper(object):
+
+    def __init__(self, driver, url, result):
+        """Performs the UI flow for the Banjo client test and records results.
+
+        Args:
+            driver: An instance of a Selenium webdriver browser class.
+            url: URL to load to start the UI flow.
+            result: NdtResult instance to populate with results from proceeding
+                through the UI flow.
+        """
+        self._driver = driver
+        self._url = url
+        self._result = result
+
+    def complete_ui_flow(self):
+        if not self._click_run_test_button():
+            return
+        # TODO(mtlynch): Implement the rest of the UI flow.
+        raise NotImplementedError('Remainder of UI flow not yet implemented.')
+
+    def _click_run_test_button(self):
+        start_button = self._driver.find_element_by_id(
+            'lrfactory-internetspeed__test_button')
+        if not start_button:
+            self._add_test_error(ERROR_FAILED_TO_LOCATE_RUN_TEST_BUTTON)
+            return False
+        # We skip waiting for the element to become visible because it should
+        # be visible as soon as the page loads.
+        start_button.click()
+        return True
+
+    def _add_test_error(self, error_message):
+        self._result.errors.append(results.TestError(error_message))

--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -50,7 +50,7 @@ class NdtHtml5SeleniumDriver(object):
         Returns:
             A populated NdtResult object.
         """
-        result = results.NdtResult(start_time=None, end_time=None, errors=[])
+        result = results.NdtResult()
         result.client = names.NDT_HTML5
         result.start_time = datetime.datetime.now(pytz.utc)
 

--- a/client_wrapper/results.py
+++ b/client_wrapper/results.py
@@ -113,7 +113,7 @@ class NdtResult(object):
     def __init__(self,
                  start_time=None,
                  end_time=None,
-                 errors=[],
+                 errors=None,
                  c2s_result=NdtSingleTestResult(),
                  s2c_result=NdtSingleTestResult(),
                  latency=None,
@@ -127,7 +127,10 @@ class NdtResult(object):
         self.end_time = end_time
         self.c2s_result = c2s_result
         self.s2c_result = s2c_result
-        self.errors = errors
+        if errors:
+            self.errors = errors
+        else:
+            self.errors = []
         self.latency = latency
         self.os = os
         self.os_version = os_version

--- a/tests/test_banjo_driver.py
+++ b/tests/test_banjo_driver.py
@@ -1,0 +1,61 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+import unittest
+
+import mock
+from client_wrapper import banjo_driver
+from client_wrapper import browser_client_common
+from client_wrapper import names
+from tests import ndt_client_test
+
+
+class BanjoDriverTest(ndt_client_test.NdtClientTest):
+
+    def setUp(self):
+        self.mock_driver = mock.Mock()
+        self.mock_driver.capabilities = {'version': 'mock_version'}
+
+        # Create mock DOM elements that are returned by calls to
+        # find_element_by_id.
+        self.mock_elements_by_id = {
+            'lrfactory-internetspeed__test_button': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: self.mock_elements_by_id[id])
+
+        # Patch the call to create the browser driver to return our mock driver.
+        create_browser_patcher = mock.patch.object(browser_client_common,
+                                                   'create_browser')
+        self.addCleanup(create_browser_patcher.stop)
+        create_browser_patcher.start()
+        browser_client_common.create_browser.return_value = self.mock_driver
+        self.banjo = banjo_driver.BanjoDriver(names.FIREFOX,
+                                              'http://fakelocalhost:1234/foo')
+
+    def test_test_records_error_when_run_test_button_is_not_in_dom(self):
+        self.mock_elements_by_id['lrfactory-internetspeed__test_button'] = None
+
+        result = self.banjo.perform_test()
+
+        self.assertIsNone(result.latency)
+        self.assertIsNone(result.s2c_result.throughput)
+        self.assertIsNone(result.c2s_result.throughput)
+        self.assertErrorMessagesEqual(
+            [banjo_driver.ERROR_FAILED_TO_LOCATE_RUN_TEST_BUTTON],
+            result.errors)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds a partial selenium driver for the Banjo client. Adds a unit test for
the currently implemented functionality.

Also fixes a minor issue with the TestResult constructor. It turns out that
using the default parameter of [] was causing all instances that used that
constructor to share the same list, which breaks unit tests. This fixes
the constructor and both client drivers' usage of the constructor.

The Banjo driver differs from the HTML5 driver in that the Banjo driver
uses a private _BanjoUiFlowWrapper so that it doesn't keep having to
pass around the "driver" and "result" parameters to different module-
level functions, but perform_test still is idempotent, which was the reason
the HTML5 driver didn't use instance variables to pass around data
in the first place. We should eventually refactor the HTML5 driver to follow
the same pattern.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/47)
<!-- Reviewable:end -->
