### PR TITLE
Adding event time recording to Banjo driver

### DIFF
--- a/client_wrapper/banjo_driver.py
+++ b/client_wrapper/banjo_driver.py
@@ -103,7 +103,7 @@ class _BanjoUiFlowWrapper(object):
         else:
             self._add_test_error(browser_client_common.ERROR_C2S_NEVER_STARTED)
 
-        # When the latency field becomes visible in the web UI, the NDT test is
+        # When the latency field becomes visible in the web UI, the C2S test is
         # complete.
         if self._wait_for_latency_field():
             self._result.c2s_result.end_time = datetime.datetime.now(pytz.utc)

--- a/client_wrapper/banjo_driver.py
+++ b/client_wrapper/banjo_driver.py
@@ -17,12 +17,20 @@ import contextlib
 import datetime
 
 import pytz
+from selenium.webdriver.support import ui
+from selenium.webdriver.support import expected_conditions
+from selenium.common import exceptions
+from selenium.webdriver.common import by
 
 import browser_client_common
 import names
 import results
 
 ERROR_FAILED_TO_LOCATE_RUN_TEST_BUTTON = 'Failed to locate "Run Speed Test" button.'
+
+# Default number of seconds to wait for any particular stage of the UI flow to
+# complete.
+_DEFAULT_TIMEOUT = 20
 
 
 class BanjoDriver(object):
@@ -79,8 +87,30 @@ class _BanjoUiFlowWrapper(object):
     def complete_ui_flow(self):
         if not self._click_run_test_button():
             return
+
+        if self._wait_for_download_test_to_start():
+            self._result.s2c_result.start_time = datetime.datetime.now(pytz.utc)
+        else:
+            self._add_test_error(browser_client_common.ERROR_S2C_NEVER_STARTED)
+
+        if self._wait_for_download_test_to_end():
+            self._result.s2c_result.end_time = datetime.datetime.now(pytz.utc)
+        else:
+            self._add_test_error(browser_client_common.ERROR_S2C_NEVER_ENDED)
+
+        if self._wait_for_upload_test_to_start():
+            self._result.c2s_result.start_time = datetime.datetime.now(pytz.utc)
+        else:
+            self._add_test_error(browser_client_common.ERROR_C2S_NEVER_STARTED)
+
+        # When the latency field becomes visible in the web UI, the NDT test is
+        # complete.
+        if self._wait_for_latency_field():
+            self._result.c2s_result.end_time = datetime.datetime.now(pytz.utc)
+        else:
+            self._add_test_error(browser_client_common.ERROR_C2S_NEVER_ENDED)
+
         # TODO(mtlynch): Implement the rest of the UI flow.
-        raise NotImplementedError('Remainder of UI flow not yet implemented.')
 
     def _click_run_test_button(self):
         start_button = self._driver.find_element_by_id(
@@ -92,6 +122,41 @@ class _BanjoUiFlowWrapper(object):
         # be visible as soon as the page loads.
         start_button.click()
         return True
+
+    def _wait_for_download_test_to_start(self):
+        return self._wait_for_status_banner_text('Testing download...')
+
+    def _wait_for_download_test_to_end(self):
+        return self._wait_for_status_banner_text(
+            'Waiting for upload to start...')
+
+    def _wait_for_upload_test_to_start(self):
+        return self._wait_for_status_banner_text('Testing upload...')
+
+    def _wait_for_status_banner_text(self, status_text):
+        """Wait until specified text appears in the status banner of the web UI.
+
+        Args:
+            status_text: The text in the web UI banner for which to wait.
+
+        Returns:
+            True if the status banner displayed the specified within the
+            timeout period.
+        """
+        try:
+            ui.WebDriverWait(self._driver, _DEFAULT_TIMEOUT).until(
+                expected_conditions.text_to_be_present_in_element(
+                    (by.By.CLASS_NAME,
+                     'lrfactory-internetspeed__status-indicator'), status_text))
+        except exceptions.TimeoutException:
+            return False
+        return True
+
+    def _wait_for_latency_field(self):
+        return browser_client_common.wait_until_element_is_visible(
+            self._driver,
+            self._driver.find_element_by_id('lrfactory-internetspeed__latency'),
+            _DEFAULT_TIMEOUT)
 
     def _add_test_error(self, error_message):
         self._result.errors.append(results.TestError(error_message))

--- a/client_wrapper/results.py
+++ b/client_wrapper/results.py
@@ -114,8 +114,8 @@ class NdtResult(object):
                  start_time=None,
                  end_time=None,
                  errors=None,
-                 c2s_result=NdtSingleTestResult(),
-                 s2c_result=NdtSingleTestResult(),
+                 c2s_result=None,
+                 s2c_result=None,
                  latency=None,
                  os=None,
                  os_version=None,
@@ -125,12 +125,9 @@ class NdtResult(object):
                  browser_version=None):
         self.start_time = start_time
         self.end_time = end_time
-        self.c2s_result = c2s_result
-        self.s2c_result = s2c_result
-        if errors:
-            self.errors = errors
-        else:
-            self.errors = []
+        self.c2s_result = c2s_result if c2s_result else NdtSingleTestResult()
+        self.s2c_result = s2c_result if s2c_result else NdtSingleTestResult()
+        self.errors = errors if errors else []
         self.latency = latency
         self.os = os
         self.os_version = os_version

--- a/tests/test_banjo_driver.py
+++ b/tests/test_banjo_driver.py
@@ -114,7 +114,7 @@ class BanjoDriverTest(ndt_client_test.NdtClientTest):
             [banjo_driver.ERROR_FAILED_TO_LOCATE_RUN_TEST_BUTTON],
             result.errors)
 
-    def test_test_in_progress_timeout_yields_timeout_errors(self):
+    def test_driver_adds_errors_if_every_wait_event_times_out(self):
         """If each test times out, expect an error for each timeout."""
         self.timeout_by_text['Testing download...'] = True
         self.timeout_by_text['Waiting for upload to start...'] = True
@@ -133,7 +133,7 @@ class BanjoDriverTest(ndt_client_test.NdtClientTest):
              browser_client_common.ERROR_C2S_NEVER_ENDED], result.errors)
 
     def test_download_start_timeout_yields_errors(self):
-        """If waiting for just download start times out, expect just one error."""
+        """If waiting for download start times out, expect just one error."""
         self.timeout_by_text['Testing download...'] = True
 
         result = self.banjo.perform_test()

--- a/tests/test_banjo_driver.py
+++ b/tests/test_banjo_driver.py
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import
+import datetime
 import unittest
 
 import mock
+import pytz
+from selenium.common import exceptions
+
 from client_wrapper import banjo_driver
 from client_wrapper import browser_client_common
 from client_wrapper import names
@@ -24,25 +28,79 @@ from tests import ndt_client_test
 class BanjoDriverTest(ndt_client_test.NdtClientTest):
 
     def setUp(self):
+        self.apply_patches_for_create_browser()
+        self.apply_patches_for_find_element_by_id()
+        self.apply_patches_for_wait_until_element_is_visible()
+        self.apply_patches_for_waiting_on_status_banner_text()
+
+        self.banjo = banjo_driver.BanjoDriver(names.FIREFOX,
+                                              'http://fakelocalhost:1234/foo')
+
+    def apply_patches_for_create_browser(self):
+        """Set up patches related to creating the Selenium Browser."""
         self.mock_driver = mock.Mock()
         self.mock_driver.capabilities = {'version': 'mock_version'}
-
-        # Create mock DOM elements that are returned by calls to
-        # find_element_by_id.
-        self.mock_elements_by_id = {
-            'lrfactory-internetspeed__test_button': mock.Mock(),
-        }
-        self.mock_driver.find_element_by_id.side_effect = (
-            lambda id: self.mock_elements_by_id[id])
-
         # Patch the call to create the browser driver to return our mock driver.
         create_browser_patcher = mock.patch.object(browser_client_common,
                                                    'create_browser')
         self.addCleanup(create_browser_patcher.stop)
         create_browser_patcher.start()
         browser_client_common.create_browser.return_value = self.mock_driver
-        self.banjo = banjo_driver.BanjoDriver(names.FIREFOX,
-                                              'http://fakelocalhost:1234/foo')
+
+    def apply_patches_for_find_element_by_id(self):
+        """Set up patches to mock find_element_by_id."""
+        # Create mock DOM elements that are returned by calls to
+        # find_element_by_id.
+        self.mock_elements_by_id = {
+            'lrfactory-internetspeed__test_button': mock.Mock(),
+            'lrfactory-internetspeed__latency': mock.Mock(),
+        }
+        self.mock_driver.find_element_by_id.side_effect = (
+            lambda id: self.mock_elements_by_id[id])
+
+    def apply_patches_for_wait_until_element_is_visible(self):
+        """Set up patches for wait_until_element_is_visible."""
+        wait_until_visible_patcher = mock.patch.object(
+            banjo_driver.browser_client_common, 'wait_until_element_is_visible')
+        self.addCleanup(wait_until_visible_patcher.stop)
+        wait_until_visible_patcher.start()
+        banjo_driver.browser_client_common.wait_until_element_is_visible.return_value = (
+            True)
+
+    def apply_patches_for_waiting_on_status_banner_text(self):
+        """Set up the patches related to waiting for status banner text."""
+        # Patch out the call to WebDriverWait so that it does nothing.
+        webdriver_wait_patcher = mock.patch.object(banjo_driver.ui,
+                                                   'WebDriverWait')
+        self.addCleanup(webdriver_wait_patcher.stop)
+        webdriver_wait_patcher.start()
+
+        # Patch the text_to_be_present_in_element function so we can throw
+        # exceptions to simulate timeouts. Note that the proper place to
+        # simulate timeouts would probably be in WebDriverWait, but it's easier
+        # to do here because this allows us better control on the basis of text
+        # to wait on.
+        text_to_be_present_patcher = mock.patch.object(
+            banjo_driver.expected_conditions, 'text_to_be_present_in_element')
+        self.addCleanup(text_to_be_present_patcher.stop)
+        text_to_be_present_patcher.start()
+
+        # A dictionary of elements to trigger timeout exceptions based on
+        # what text the caller is waiting for. A value of False means throw no
+        # exception (simulate a successful wait), True means throw a timeout
+        # exception (simulate a failed wait).
+        self.timeout_by_text = {
+            'Testing download...': False,
+            'Waiting for upload to start...': False,
+            'Testing upload...': False,
+        }
+
+        def mock_text_to_be_present_in_element(_, text):
+            if self.timeout_by_text[text]:
+                raise exceptions.TimeoutException('mock timeout')
+
+        banjo_driver.expected_conditions.text_to_be_present_in_element.side_effect = (
+            mock_text_to_be_present_in_element)
 
     def test_test_records_error_when_run_test_button_is_not_in_dom(self):
         self.mock_elements_by_id['lrfactory-internetspeed__test_button'] = None
@@ -55,6 +113,67 @@ class BanjoDriverTest(ndt_client_test.NdtClientTest):
         self.assertErrorMessagesEqual(
             [banjo_driver.ERROR_FAILED_TO_LOCATE_RUN_TEST_BUTTON],
             result.errors)
+
+    def test_test_in_progress_timeout_yields_timeout_errors(self):
+        """If each test times out, expect an error for each timeout."""
+        self.timeout_by_text['Testing download...'] = True
+        self.timeout_by_text['Waiting for upload to start...'] = True
+        self.timeout_by_text['Testing upload...'] = True
+        # Simulate a timeout when waiting for the "latency" field (which we use
+        # as a proxy for the results view).
+        banjo_driver.browser_client_common.wait_until_element_is_visible.return_value = (
+            False)
+
+        result = self.banjo.perform_test()
+
+        self.assertErrorMessagesEqual(
+            [browser_client_common.ERROR_S2C_NEVER_STARTED,
+             browser_client_common.ERROR_S2C_NEVER_ENDED,
+             browser_client_common.ERROR_C2S_NEVER_STARTED,
+             browser_client_common.ERROR_C2S_NEVER_ENDED], result.errors)
+
+    def test_download_start_timeout_yields_errors(self):
+        """If waiting for just download start times out, expect just one error."""
+        self.timeout_by_text['Testing download...'] = True
+
+        result = self.banjo.perform_test()
+
+        self.assertErrorMessagesEqual(
+            [browser_client_common.ERROR_S2C_NEVER_STARTED], result.errors)
+
+    def test_driver_records_event_times_correctly(self):
+        # Create a list of mock times to be returned by datetime.now().
+        times = []
+        for i in range(7):
+            times.append(datetime.datetime(2016, 1, 1, 0, 0, i))
+
+        with mock.patch.object(banjo_driver.datetime,
+                               'datetime',
+                               autospec=True) as mocked_datetime:
+            # Patch datetime.now to return the next mock time on every call to
+            # now().
+            mocked_datetime.now.side_effect = times
+
+            # Modify the create_browser mock to increment the clock forward one
+            # call so we can verify that the browser is created after
+            # result.start_time.
+            def mock_create_browser(unused_browser_name):
+                datetime.datetime.now(pytz.utc)
+                return self.mock_driver
+
+            browser_client_common.create_browser.side_effect = (
+                mock_create_browser)
+
+            result = self.banjo.perform_test()
+
+        # Verify the recorded times matches the expected sequence.
+        self.assertEqual(times[0], result.start_time)
+        # times[1] is the call from mock_create_browser.
+        self.assertEqual(times[2], result.s2c_result.start_time)
+        self.assertEqual(times[3], result.s2c_result.end_time)
+        self.assertEqual(times[4], result.c2s_result.start_time)
+        self.assertEqual(times[5], result.c2s_result.end_time)
+        self.assertEqual(times[6], result.end_time)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds functionality to the Banjo driver to allow it to record the relevant
event times of the test.

Also fixes a small bug in results.NdtResult where the constructor was
assigning default values that got re-used between calls (breaking tests).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/48)
<!-- Reviewable:end -->
