### PR TITLE
Adding handling for blank latency field

### DIFF
--- a/client_wrapper/banjo_driver.py
+++ b/client_wrapper/banjo_driver.py
@@ -33,11 +33,11 @@ ERROR_FAILED_TO_LOCATE_RUN_TEST_BUTTON = (
 ERROR_NO_LATENCY_FIELD = 'Could not find latency field.'
 ERROR_NO_S2C_FIELD = 'Could not find s2c throughput field.'
 ERROR_NO_C2S_FIELD = 'Could not find c2s throughput field.'
-ERROR_FORMAT_ILLEGAL_LATENCY = 'Illegal value shown for latency: %s'
+ERROR_FORMAT_ILLEGAL_LATENCY = 'Illegal value shown for latency: [%s]'
 ERROR_FORMAT_ILLEGAL_S2C_THROUGHPUT = (
-    'Illegal value shown for s2c throughput: %s')
+    'Illegal value shown for s2c throughput: [%s]')
 ERROR_FORMAT_ILLEGAL_C2S_THROUGHPUT = (
-    'Illegal value shown for c2s throughput: %s')
+    'Illegal value shown for c2s throughput: [%s]')
 
 # Default number of seconds to wait for any particular stage of the UI flow to
 # complete.
@@ -204,6 +204,10 @@ class _BanjoUiFlowWrapper(object):
         # The latency is stored as "[value] ms" like "12 ms" so we split the
         # string and use the numeric portion.
         latency_text = latency_element.text
+        if not latency_text:
+            self._add_test_error(ERROR_FORMAT_ILLEGAL_LATENCY %
+                                 latency_element.text)
+            return None
         latency_value_parts = latency_text.split()
         latency_value = latency_value_parts[0]
         try:

--- a/tests/test_banjo_driver.py
+++ b/tests/test_banjo_driver.py
@@ -198,6 +198,46 @@ class BanjoDriverTest(ndt_client_test.NdtClientTest):
         self.assertEqual(times[5], result.c2s_result.end_time)
         self.assertEqual(times[6], result.end_time)
 
+    def test_errors_occur_when_results_page_displays_blank_latency(self):
+        self.mock_elements_by_xpath[
+            '//div[@id="lrfactory-internetspeed__latency"]/*[2]'] = mock.Mock(
+                text='')
+        result = self.banjo.perform_test()
+
+        self.assertIsNone(result.latency)
+        self.assertEqual(4.56, result.s2c_result.throughput)
+        self.assertEqual(7.89, result.c2s_result.throughput)
+        self.assertErrorMessagesEqual(
+            ['Illegal value shown for latency: []'], result.errors)
+
+    def test_errors_occur_when_results_page_displays_blank_download_throughput(
+            self):
+        self.mock_elements_by_xpath[
+            '//div[@id="lrfactory-internetspeed__download"]/*[1]'] = mock.Mock(
+                text='')
+
+        result = self.banjo.perform_test()
+
+        self.assertEqual(1.23, result.latency)
+        self.assertIsNone(result.s2c_result.throughput)
+        self.assertEqual(7.89, result.c2s_result.throughput)
+        self.assertErrorMessagesEqual(
+            ['Illegal value shown for s2c throughput: []'], result.errors)
+
+    def test_errors_occur_when_results_page_displays_blank_upload_throughput(
+            self):
+        self.mock_elements_by_xpath[
+            '//div[@id="lrfactory-internetspeed__upload"]/*[1]'] = mock.Mock(
+                text='')
+
+        result = self.banjo.perform_test()
+
+        self.assertEqual(1.23, result.latency)
+        self.assertEqual(4.56, result.s2c_result.throughput)
+        self.assertIsNone(result.c2s_result.throughput)
+        self.assertErrorMessagesEqual(
+            ['Illegal value shown for c2s throughput: []'], result.errors)
+
     def test_errors_occur_when_results_page_displays_non_numeric_latency(self):
         self.mock_elements_by_xpath[
             '//div[@id="lrfactory-internetspeed__latency"]/*[2]'] = mock.Mock(
@@ -208,7 +248,7 @@ class BanjoDriverTest(ndt_client_test.NdtClientTest):
         self.assertEqual(4.56, result.s2c_result.throughput)
         self.assertEqual(7.89, result.c2s_result.throughput)
         self.assertErrorMessagesEqual(
-            ['Illegal value shown for latency: banana ms'], result.errors)
+            ['Illegal value shown for latency: [banana ms]'], result.errors)
 
     def test_errors_occur_when_results_page_displays_non_numeric_download_throughput(
             self):
@@ -222,7 +262,7 @@ class BanjoDriverTest(ndt_client_test.NdtClientTest):
         self.assertIsNone(result.s2c_result.throughput)
         self.assertEqual(7.89, result.c2s_result.throughput)
         self.assertErrorMessagesEqual(
-            ['Illegal value shown for s2c throughput: banana'], result.errors)
+            ['Illegal value shown for s2c throughput: [banana]'], result.errors)
 
     def test_errors_occur_when_results_page_displays_non_numeric_upload_throughput(
             self):
@@ -236,7 +276,7 @@ class BanjoDriverTest(ndt_client_test.NdtClientTest):
         self.assertEqual(4.56, result.s2c_result.throughput)
         self.assertIsNone(result.c2s_result.throughput)
         self.assertErrorMessagesEqual(
-            ['Illegal value shown for c2s throughput: banana'], result.errors)
+            ['Illegal value shown for c2s throughput: [banana]'], result.errors)
 
     def test_errors_occur_when_results_page_displays_all_non_numeric_metrics(
             self):
@@ -262,9 +302,9 @@ class BanjoDriverTest(ndt_client_test.NdtClientTest):
         self.assertIsNone(result.s2c_result.throughput)
         self.assertIsNone(result.c2s_result.throughput)
         self.assertErrorMessagesEqual(
-            ['Illegal value shown for latency: apple',
-             'Illegal value shown for s2c throughput: banana',
-             'Illegal value shown for c2s throughput: cherry'], result.errors)
+            ['Illegal value shown for latency: [apple]',
+             'Illegal value shown for s2c throughput: [banana]',
+             'Illegal value shown for c2s throughput: [cherry]'], result.errors)
 
     def test_records_error_when_latency_element_is_not_in_dom(self):
         self.mock_elements_by_xpath[


### PR DESCRIPTION
Adds graceful handling for the case when the latency field of the results
page has no value. Adds unit tests to verify graceful handling of empty values
for latency, download throughput, and upload throughput.

Changes the error message for unexpected values slightly to make it clearer
in the case of blank field values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/54)
<!-- Reviewable:end -->
