### PR TITLE
Fixing client wrapper so it always quit()s Selenium

### DIFF
--- a/client_wrapper/banjo_driver.py
+++ b/client_wrapper/banjo_driver.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from __future__ import division
-import contextlib
 import datetime
 
 import pytz
@@ -65,8 +64,7 @@ class BanjoDriver(object):
         result = results.NdtResult(client=names.BANJO,
                                    start_time=datetime.datetime.now(pytz.utc))
 
-        with contextlib.closing(browser_client_common.create_browser(
-                self._browser)) as driver:
+        with browser_client_common.create_browser(self._browser) as driver:
             result.browser = self._browser
             result.browser_version = driver.capabilities['version']
 

--- a/client_wrapper/browser_client_common.py
+++ b/client_wrapper/browser_client_common.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
+
 from selenium import webdriver
 from selenium.common import exceptions
 from selenium.webdriver.support import expected_conditions
@@ -30,25 +32,34 @@ ERROR_C2S_NEVER_ENDED = 'Timed out waiting for c2s test to end.'
 ERROR_S2C_NEVER_ENDED = 'Timed out waiting for s2c test to end.'
 
 
+@contextlib.contextmanager
 def create_browser(browser):
-    """Creates a Selenium-controlled web browser.
+    """Creates a context manager for a Selenium-controlled web browser.
+
+    Creates a context manager to produce a Selenium-driven web browser. The
+    Caller should call this function from within a with block so that the
+    Selenium resources are freed properly when the browser is no longer needed.
 
     Args:
         browser: Can be one of 'firefox', 'chrome', 'edge', or 'safari'
 
-    Returns:
+    Yields:
         An instance of a Selenium webdriver browser class corresponding to
         the specified browser.
     """
     if browser == names.FIREFOX:
-        return webdriver.Firefox()
+        driver = webdriver.Firefox()
     elif browser == names.CHROME:
-        return webdriver.Chrome()
+        driver = webdriver.Chrome()
     elif browser == names.EDGE:
-        return webdriver.Edge()
+        driver = webdriver.Edge()
     elif browser == names.SAFARI:
-        return webdriver.Safari()
-    raise ValueError('Invalid browser specified: %s' % browser)
+        driver = webdriver.Safari()
+    else:
+        raise ValueError('Invalid browser specified: %s' % browser)
+
+    yield driver
+    driver.quit()
 
 
 def load_url(driver, url, errors):

--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from __future__ import division
-import contextlib
 import datetime
 
 import pytz
@@ -57,8 +56,7 @@ class NdtHtml5SeleniumDriver(object):
         result.client = names.NDT_HTML5
         result.start_time = datetime.datetime.now(pytz.utc)
 
-        with contextlib.closing(browser_client_common.create_browser(
-                self._browser)) as driver:
+        with browser_client_common.create_browser(self._browser) as driver:
             result.browser = self._browser
             result.browser_version = driver.capabilities['version']
 

--- a/tests/ndt_client_test.py
+++ b/tests/ndt_client_test.py
@@ -11,7 +11,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import contextlib
 import unittest
+
+import mock
+
+from client_wrapper import browser_client_common
 
 
 class NdtClientTest(unittest.TestCase):
@@ -27,3 +32,19 @@ class NdtClientTest(unittest.TestCase):
         """
         actual_messages = [e.message for e in actual_errors]
         self.assertListEqual(expected_messages, actual_messages)
+
+    def apply_patches_for_create_browser(self):
+        """Set up patches related to creating the Selenium Browser."""
+        self.mock_driver = mock.Mock()
+        self.mock_driver.capabilities = {'version': 'mock_version'}
+
+        @contextlib.contextmanager
+        def mock_create_browser(browser):
+            yield self.mock_driver
+
+        # Patch the call to create the browser driver to return our mock driver.
+        create_browser_patcher = mock.patch.object(browser_client_common,
+                                                   'create_browser')
+        self.addCleanup(create_browser_patcher.stop)
+        create_browser_patcher.start()
+        browser_client_common.create_browser.side_effect = mock_create_browser

--- a/tests/ndt_client_testcase.py
+++ b/tests/ndt_client_testcase.py
@@ -19,7 +19,7 @@ import mock
 from client_wrapper import browser_client_common
 
 
-class NdtClientTest(unittest.TestCase):
+class NdtClientTestCase(unittest.TestCase):
     """Base class for unit tests of NDT clients.
 
     Defines common functions needed in unit tests of NDT clients.

--- a/tests/test_banjo_driver.py
+++ b/tests/test_banjo_driver.py
@@ -23,10 +23,10 @@ from selenium.common import exceptions
 from client_wrapper import banjo_driver
 from client_wrapper import browser_client_common
 from client_wrapper import names
-from tests import ndt_client_test
+from tests import ndt_client_testcase
 
 
-class BanjoDriverTest(ndt_client_test.NdtClientTest):
+class BanjoDriverTest(ndt_client_testcase.NdtClientTestCase):
 
     def setUp(self):
         self.apply_patches_for_create_browser()

--- a/tests/test_browser_client_common.py
+++ b/tests/test_browser_client_common.py
@@ -27,39 +27,60 @@ class CreateBrowserTest(unittest.TestCase):
 
     @mock.patch.object(browser_client_common.webdriver, 'Firefox')
     def test_create_firefox_browser_succeeds(self, mock_firefox):
-        mock_firefox.return_value = 'mock firefox driver'
+        mock_browser_driver = mock.Mock('mock firefox driver')
+        mock_browser_driver.quit = mock.Mock()
+        mock_firefox.return_value = mock_browser_driver
 
-        self.assertEqual('mock firefox driver',
-                         browser_client_common.create_browser(names.FIREFOX))
-        self.assertTrue(mock_firefox.called)
+        with browser_client_common.create_browser(names.FIREFOX) as driver:
+            self.assertTrue(mock_firefox.called)
+            self.assertEqual(mock_browser_driver, driver)
+            self.assertFalse(mock_browser_driver.quit.called)
+
+        self.assertTrue(mock_browser_driver.quit.called)
 
     @mock.patch.object(browser_client_common.webdriver, 'Chrome')
     def test_create_chrome_browser_succeeds(self, mock_chrome):
-        mock_chrome.return_value = 'mock chrome driver'
+        mock_browser_driver = mock.Mock('mock chrome driver')
+        mock_browser_driver.quit = mock.Mock()
+        mock_chrome.return_value = mock_browser_driver
 
-        self.assertEqual('mock chrome driver',
-                         browser_client_common.create_browser(names.CHROME))
-        self.assertTrue(mock_chrome.called)
+        with browser_client_common.create_browser(names.CHROME) as driver:
+            self.assertTrue(mock_chrome.called)
+            self.assertEqual(mock_browser_driver, driver)
+            self.assertFalse(mock_browser_driver.quit.called)
+
+        self.assertTrue(mock_browser_driver.quit.called)
 
     @mock.patch.object(browser_client_common.webdriver, 'Edge')
     def test_create_edge_driver_succeeds(self, mock_edge):
-        mock_edge.return_value = 'mock edge driver'
+        mock_browser_driver = mock.Mock('mock edge driver')
+        mock_browser_driver.quit = mock.Mock()
+        mock_edge.return_value = mock_browser_driver
 
-        self.assertEqual('mock edge driver',
-                         browser_client_common.create_browser(names.EDGE))
-        self.assertTrue(mock_edge.called)
+        with browser_client_common.create_browser(names.EDGE) as driver:
+            self.assertTrue(mock_edge.called)
+            self.assertEqual(mock_browser_driver, driver)
+            self.assertFalse(mock_browser_driver.quit.called)
+
+        self.assertTrue(mock_browser_driver.quit.called)
 
     @mock.patch.object(browser_client_common.webdriver, 'Safari')
     def test_create_safari_browser_succeeds(self, mock_safari):
-        mock_safari.return_value = 'mock safari driver'
+        mock_browser_driver = mock.Mock('mock safari driver')
+        mock_browser_driver.quit = mock.Mock()
+        mock_safari.return_value = mock_browser_driver
 
-        self.assertEqual('mock safari driver',
-                         browser_client_common.create_browser(names.SAFARI))
-        self.assertTrue(mock_safari.called)
+        with browser_client_common.create_browser(names.SAFARI) as driver:
+            self.assertTrue(mock_safari.called)
+            self.assertEqual(mock_browser_driver, driver)
+            self.assertFalse(mock_browser_driver.quit.called)
+
+        self.assertTrue(mock_browser_driver.quit.called)
 
     def test_create_unrecognized_browser_raises_error(self):
         with self.assertRaises(ValueError):
-            browser_client_common.create_browser('not a real browser name')
+            with browser_client_common.create_browser('foo'):
+                pass
 
 
 class LoadUrlTest(ndt_client_test.NdtClientTest):

--- a/tests/test_browser_client_common.py
+++ b/tests/test_browser_client_common.py
@@ -19,7 +19,7 @@ from selenium.common import exceptions
 
 from client_wrapper import browser_client_common
 from client_wrapper import names
-from tests import ndt_client_test
+from tests import ndt_client_testcase
 
 
 class CreateBrowserTest(unittest.TestCase):
@@ -83,7 +83,7 @@ class CreateBrowserTest(unittest.TestCase):
                 pass
 
 
-class LoadUrlTest(ndt_client_test.NdtClientTest):
+class LoadUrlTest(ndt_client_testcase.NdtClientTestCase):
     """Tests for load_url function."""
 
     def test_load_url_loads_correct_url(self):

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -21,10 +21,10 @@ import pytz
 
 from client_wrapper import browser_client_common
 from client_wrapper import html5_driver
-from tests import ndt_client_test
+from tests import ndt_client_testcase
 
 
-class NdtHtml5SeleniumDriverTest(ndt_client_test.NdtClientTest):
+class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
 
     def setUp(self):
         self.apply_patches_for_create_browser()

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import
+import contextlib
 import datetime
 import unittest
 
@@ -26,9 +27,7 @@ from tests import ndt_client_test
 class NdtHtml5SeleniumDriverTest(ndt_client_test.NdtClientTest):
 
     def setUp(self):
-        self.mock_driver = mock.Mock()
-        self.mock_driver.capabilities = {'version': 'mock_version'}
-
+        self.apply_patches_for_create_browser()
         wait_until_visible_patcher = mock.patch.object(
             html5_driver.browser_client_common, 'wait_until_element_is_visible')
         self.addCleanup(wait_until_visible_patcher.stop)
@@ -63,13 +62,6 @@ class NdtHtml5SeleniumDriverTest(ndt_client_test.NdtClientTest):
         create_browser_patcher.start()
         browser_client_common.find_element_containing_text.side_effect = (
             lambda _, text: self.mock_elements_by_text[text])
-
-        # Patch the call to create the browser driver to return our mock driver.
-        create_browser_patcher = mock.patch.object(browser_client_common,
-                                                   'create_browser')
-        self.addCleanup(create_browser_patcher.stop)
-        create_browser_patcher.start()
-        browser_client_common.create_browser.return_value = self.mock_driver
 
     def test_test_yields_valid_results_when_all_page_elements_are_expected_values(
             self):
@@ -289,9 +281,10 @@ class NdtHtml5SeleniumDriverTest(ndt_client_test.NdtClientTest):
 
             # Modify the create_browser mock to increment the clock forward one
             # call.
+            @contextlib.contextmanager
             def mock_create_browser(unused_browser_name):
                 datetime.datetime.now(pytz.utc)
-                return self.mock_driver
+                yield self.mock_driver
 
             browser_client_common.create_browser.side_effect = (
                 mock_create_browser)


### PR DESCRIPTION
This fixes a bug in that the client_wrapper was just calling close() on
the Selenium driver, which closes the browser window, but does not free
resources associated with the browser driver. To do that, we need to call
quit().

This changes create_browser to a context manager so that callers can call
it in a with block that automatically calls quit() at the end. Updates the
unit tests to match.

Small refactoring of apply_patches_for_create_browser so that it's now shared
between both the banjo tests and the HTML5 tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/55)
<!-- Reviewable:end -->
