### PR TITLE
Fixing driver version check to work with Microsoft Edge

### DIFF
--- a/client_wrapper/banjo_driver.py
+++ b/client_wrapper/banjo_driver.py
@@ -66,7 +66,8 @@ class BanjoDriver(object):
 
         with browser_client_common.create_browser(self._browser) as driver:
             result.browser = self._browser
-            result.browser_version = driver.capabilities['version']
+            result.browser_version = browser_client_common.get_browser_version(
+                driver)
 
             if not browser_client_common.load_url(driver, self._url,
                                                   result.errors):

--- a/client_wrapper/browser_client_common.py
+++ b/client_wrapper/browser_client_common.py
@@ -32,6 +32,15 @@ ERROR_C2S_NEVER_ENDED = 'Timed out waiting for c2s test to end.'
 ERROR_S2C_NEVER_ENDED = 'Timed out waiting for s2c test to end.'
 
 
+class Error(Exception):
+    pass
+
+
+class BrowserVersionMissing(Error):
+    """Error raised when a browser version does not apper in Selenium driver."""
+    pass
+
+
 @contextlib.contextmanager
 def create_browser(browser):
     """Creates a context manager for a Selenium-controlled web browser.
@@ -60,6 +69,30 @@ def create_browser(browser):
 
     yield driver
     driver.quit()
+
+
+def get_browser_version(driver):
+    """Determine the browser version for a Selenium WebDriver instance.
+
+    Args:
+        driver: A Selenium WebDriver instance.
+
+    Returns:
+        A version string for the browser, e.g. "45.0.3".
+
+    Raises:
+        BrowserVersionMissing: Browser version could not be determined.
+    """
+    # Most drivers put the version information in the 'version' field.
+    if 'version' in driver.capabilities:
+        return driver.capabilities['version']
+    # Drivers like Edge's WebDriver lack a 'version' field and instead have a
+    # 'browserVersion' field.
+    elif 'browserVersion' in driver.capabilities:
+        return driver.capabilities['browserVersion']
+    else:
+        raise BrowserVersionMissing(
+            'Could not identify browser version from driver.')
 
 
 def load_url(driver, url, errors):

--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -58,7 +58,8 @@ class NdtHtml5SeleniumDriver(object):
 
         with browser_client_common.create_browser(self._browser) as driver:
             result.browser = self._browser
-            result.browser_version = driver.capabilities['version']
+            result.browser_version = browser_client_common.get_browser_version(
+                driver)
 
             _complete_ui_flow(driver, self._url, self._timeout, result)
 

--- a/tests/test_browser_client_common.py
+++ b/tests/test_browser_client_common.py
@@ -83,6 +83,34 @@ class CreateBrowserTest(unittest.TestCase):
                 pass
 
 
+class GetBrowserVersionTest(unittest.TestCase):
+
+    def test_get_version_returns_successfully_when_driver_has_standard_version(
+            self):
+        mock_driver = mock.Mock()
+        mock_driver.capabilities = {'version': '1.2.3'}
+
+        self.assertEqual('1.2.3',
+                         browser_client_common.get_browser_version(mock_driver))
+
+    def test_get_version_returns_successfully_when_driver_has_edge_style_version(
+            self):
+        """Microsoft Edge's WebDriver puts version in 'browserVersion' field."""
+        mock_driver = mock.Mock()
+        mock_driver.capabilities = {'browserVersion': '1.2.3'}
+
+        self.assertEqual('1.2.3',
+                         browser_client_common.get_browser_version(mock_driver))
+
+    def test_get_version_raises_BrowserVersionMissing_when_driver_has_no_version(
+            self):
+        mock_driver = mock.Mock()
+        mock_driver.capabilities = {}
+
+        with self.assertRaises(browser_client_common.BrowserVersionMissing):
+            browser_client_common.get_browser_version(mock_driver)
+
+
 class LoadUrlTest(ndt_client_testcase.NdtClientTestCase):
     """Tests for load_url function."""
 


### PR DESCRIPTION
Microsoft's WebDriver for edge places the browser version information in the
'browserVersion' field instead of the 'version' field. This adds a function
that checks both fields if a 'version' field is not present and refactors
both the banjo and HTML5 clients to use this function instead of reading the
'version' field directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/57)
<!-- Reviewable:end -->
