### PR TITLE
Fixing race condition in HTTPReplayServer

### DIFF
--- a/client_wrapper/http_server.py
+++ b/client_wrapper/http_server.py
@@ -45,7 +45,7 @@ class HttpWaitTimeoutError(Error):
     def __init__(self, port):
         super(HttpWaitTimeoutError, self).__init__(
             'Wait timeout exceeded when waiting for a response on local port ' +
-            port)
+            str(port))
 
 
 class ReplayHTTPServer(object):
@@ -100,6 +100,7 @@ class ReplayHTTPServer(object):
         """
         self._mlabns_thread = threading.Thread(
             target=self._mlabns_server.serve_forever)
+        self._mlabns_thread.daemon = True
         self._mlabns_thread.start()
         self._wait_for_local_http_response(self._mlabns_server.port)
 

--- a/client_wrapper/http_server.py
+++ b/client_wrapper/http_server.py
@@ -17,9 +17,13 @@ Defines various HTTP server classes meant for hosting web-based NDT client
 implementations.
 """
 
+import datetime
 import re
 import subprocess
 import threading
+import urllib
+
+import pytz
 
 
 class Error(Exception):
@@ -33,6 +37,15 @@ class MitmProxyNotInstalledError(Error):
         super(MitmProxyNotInstalledError, self).__init__(
             'Failed to execute mitmdump utility. Is mitmproxy installed? '
             'http://docs.mitmproxy.org/en/stable/install.html')
+
+
+class HttpWaitTimeoutError(Error):
+    """Error raised when waiting for an HTTP response timed out."""
+
+    def __init__(self, port):
+        super(HttpWaitTimeoutError, self).__init__(
+            'Wait timeout exceeded when waiting for a response on local port ' +
+            port)
 
 
 class ReplayHTTPServer(object):
@@ -67,39 +80,33 @@ class ReplayHTTPServer(object):
         self._mlabns_server = mlabns_server
         self._replay_filename = replay_filename
         self._mlabns_thread = None
-        self._mlabns_serving_event = threading.Event()
         self._server_proc = None
-        self._start_async()
+        self._start()
 
-    def _start_async(self):
+    def _start(self):
         """Start the replay HTTP traffic server asynchronously.
 
         Starts the replay HTTP server in a separate process and the fake mlab-ns
         server in a separate thread.
         """
-        self._start_fake_mlabns_async()
-        self._start_mitmdump_async()
+        self._start_fake_mlabns()
+        self._start_mitmdump()
 
-    def _start_fake_mlabns_async(self):
+    def _start_fake_mlabns(self):
         """Start the fake mlab-ns server in a background thread.
 
         Start the fake mlab-ns server in a background thread, but block until
-        that thread begins.
+        the server begins serving responses.
         """
-        self._mlabns_thread = threading.Thread(target=self._start_fake_mlabns)
+        self._mlabns_thread = threading.Thread(
+            target=self._mlabns_server.serve_forever)
         self._mlabns_thread.start()
-        self._mlabns_serving_event.wait()
+        self._wait_for_local_http_response(self._mlabns_server.port)
 
-    def _start_fake_mlabns(self):
-        # Set the serving event to indicate that fake mlab-ns server is serving.
-        # Note: There is a race condition here, as there is a delay between the
-        # time the event is set and the time the server actually begins serving.
-        # We assume that this is good enough for now.
-        self._mlabns_serving_event.set()
-        self._mlabns_server.serve_forever()
-
-    def _start_mitmdump_async(self):
+    def _start_mitmdump(self):
         """Starts a mitmdump process as a reverse proxy to replay traffic.
+
+        Starts mitmdump process and wait for it to begin serving responses.
 
         Note that it is in theory possible to launch mitmdump in pure Python
         using the mitmproxy package. We choose not to because those APIs are
@@ -136,6 +143,23 @@ class ReplayHTTPServer(object):
                                                  stdout=subprocess.PIPE)
         except OSError:
             raise MitmProxyNotInstalledError()
+
+        self._wait_for_local_http_response(self._listen_port)
+
+    def _wait_for_local_http_response(self, port):
+        """Wait for a local port to begin responding to HTTP requests."""
+        # Maximum number of seconds to wait for a port to begin responding to
+        # HTTP requests.
+        max_wait_seconds = 5
+        start_time = datetime.datetime.now(tz=pytz.utc)
+        while (datetime.datetime.now(tz=pytz.utc) -
+               start_time).total_seconds() < max_wait_seconds:
+            try:
+                urllib.urlopen('http://localhost:%d/' % port)
+                return
+            except IOError:
+                pass
+        raise HttpWaitTimeoutError(port)
 
     def close(self):
         """Close the replay server by terminating all background workers.


### PR DESCRIPTION
The ReplayHTTPServer had an issue in that when it started up, it wouldn't
necessarily be serving HTTP requests yet because it started the actual
servers in background threads. This change explicitly waits until the
background threads are actually serving HTTP requests before returning.

Note: This is an uglier and more convoluted solution than I want, but it's
the best thing I can think of. I'm open to other solutions that eliminate
this race condition.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/59)
<!-- Reviewable:end -->
