### PR TITLE
Fixing a crash in banjo driver

### DIFF
--- a/client_wrapper/banjo_driver.py
+++ b/client_wrapper/banjo_driver.py
@@ -68,11 +68,9 @@ class BanjoDriver(object):
             result.browser = self._browser
             result.browser_version = driver.capabilities['version']
 
-            if not browser_client_common.load_url(driver, self._url,
-                                                  result.errors):
-                return
-
-            _BanjoUiFlowWrapper(driver, self._url, result).complete_ui_flow()
+            if browser_client_common.load_url(driver, self._url, result.errors):
+                _BanjoUiFlowWrapper(driver, self._url,
+                                    result).complete_ui_flow()
 
         result.end_time = datetime.datetime.now(pytz.utc)
         return result


### PR DESCRIPTION
This fixes a crash in the banjo driver that occurred when load_url failed.
The failure would cause perform_test to return None, but callers expect it
to return a populated NdtResult object.

This fixes perform_test so that it always returns a populated NdtResult
even if load_url fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/62)
<!-- Reviewable:end -->
