### PR TITLE
Adding fine-grained logging

### DIFF
--- a/client_wrapper/fake_mlabns.py
+++ b/client_wrapper/fake_mlabns.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 import json
+import logging
 import BaseHTTPServer
+
+logger = logging.getLogger(__name__)
 
 
 class FakeMLabNsServer(BaseHTTPServer.HTTPServer):
@@ -73,6 +76,5 @@ class _FakeMLabNsHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         }
         self.wfile.write(json.dumps(response))
 
-    def log_message(self, unused_format, *args):
-        """Silence console output."""
-        pass
+    def log_message(self, format, *args):
+        logger.info(format, *args)


### PR DESCRIPTION
This adds fine grained logging to the client wrapper. Specifically:

* Adds logging to the NDT HTML5 client wrapper
* Adds logging to the banjo driver
* Adds logging to fake mlab-ns
* Adds logging to top-level CLI module

A few notes:

We use the INFO level rather than the DEBUG level because once we use DEBUG,
Selenium's debug-level logging floods the logs. It might be possible to do
per-module debug-level, but for simplicity, it seemed easiest to start with
INFO.

There's a lot of redundancy in the logging in html5_driver.py. I didn't try
too hard to eliminate it because I expect that once we refactor html5_driver
to the same structure as banjo_driver, the logging will be as easy as it is
in banjo_driver.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/66)
<!-- Reviewable:end -->
