### PR TITLE
Adding HTTP response class

### DIFF
--- a/client_wrapper/http_response.py
+++ b/client_wrapper/http_response.py
@@ -19,7 +19,7 @@ class Error(Exception):
     pass
 
 
-class MissingFieldError(Exception):
+class MissingFieldError(Error):
     """Error raised when YAML-serialized HttpResponse is missing fields."""
 
     def __init__(self, field):

--- a/client_wrapper/http_response.py
+++ b/client_wrapper/http_response.py
@@ -1,0 +1,105 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import yaml
+
+
+class Error(Exception):
+    pass
+
+
+class MissingFieldError(Exception):
+    """Error raised when YAML-serialized HttpResponse is missing fields."""
+
+    def __init__(self, field):
+        super(MissingFieldError, self).__init__(
+            'Failed to parse HttpResponse from yaml, missing expected field: %s'
+            % field)
+
+
+class HttpResponse(yaml.YAMLObject):
+    """Representation of an HTTP server response.
+
+    Attributes:
+        response_code: The response code of the HTTP response (e.g. 200).
+        headers: A dictionary of key-value pairs representing the HTTP headers
+            in the response.
+        data: The data payload of the HTTP response.
+    """
+
+    yaml_tag = 'u!HttpResponse'
+
+    def __init__(self, response_code, headers, data):
+        self.response_code = response_code
+        self.headers = headers
+        self.data = data
+
+    def __eq__(self, other):
+        if not other:
+            return False
+        return all(((self.response_code == other.response_code), (
+            self.headers == other.headers), (self.data == other.data)))
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+def parse_yaml(yaml_contents):
+    """Parses a YAML string, deserializing any HttpResponse objects.
+
+    Args:
+        yaml_contents: The YAML string to parse.
+
+    Returns:
+        The parsed contents of the YAML string.
+
+    Raises:
+        MissingFieldError: The YAML contained an HttpResponse object without all
+            of its fields.
+    """
+    yaml.add_constructor(HttpResponse.yaml_tag, _http_response_constructor)
+    return yaml.load(yaml_contents)
+
+
+def _http_response_constructor(loader, node):
+    """Inner method to define a parsing constructor for HttpResponse.
+
+    Constructs a parsing constructor for HttpResponse. See:
+    http://pyyaml.org/wiki/PyYAMLDocumentation for details.
+
+    Args:
+        loader: PyYAML loader instance.
+        node: PyYAML node instance.
+
+    Returns:
+        Populated HttpResponse instance.
+
+    Raises:
+        MissingFieldError: The YAML contained an HttpResponse object without all
+            of its fields.
+    """
+    values = loader.construct_mapping(node)
+    try:
+        response_code = values['response_code']
+    except KeyError:
+        raise MissingFieldError('response_code')
+    try:
+        headers = values['headers']
+    except KeyError:
+        raise MissingFieldError('headers')
+    try:
+        data = values['data']
+    except KeyError:
+        raise MissingFieldError('data')
+    return HttpResponse(response_code, headers, data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-dateutil
 pytz==2016.2
+pyyaml
 selenium==2.53.1

--- a/tests/test_http_response.py
+++ b/tests/test_http_response.py
@@ -1,0 +1,89 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+import unittest
+
+from client_wrapper import http_response
+
+
+class HttpResponseTest(unittest.TestCase):
+
+    def test_identical_responses_evaluate_as_equal(self):
+        a = http_response.HttpResponse(200, {'Mock-Header': 'OK'}, 'mock data')
+        a_equivalent = http_response.HttpResponse(200, {'Mock-Header': 'OK'},
+                                                  'mock data')
+        self.assertEqual(a, a_equivalent)
+
+    def test_different_responses_evaluate_as_unequal(self):
+        # Create baseline response.
+        a = http_response.HttpResponse(200, {'Mock-Header': 'OK'}, 'mock data')
+
+        # Different response code field.
+        b = http_response.HttpResponse(500, {'Mock-Header': 'OK'}, 'mock data')
+        self.assertNotEqual(a, b)
+
+        # Different header field.
+        c = http_response.HttpResponse(200, {'Mock-Header': 'FAIL'},
+                                       'mock data')
+        self.assertNotEqual(a, c)
+
+        # Different data field.
+        d = http_response.HttpResponse(200, {'Mock-Header': 'OK'},
+                                       'mock different data')
+        self.assertNotEqual(a, d)
+
+    def test_parse_yaml_can_successfully_parse_dictionary_of_responses(self):
+        yaml_contents = """---
+/foo: !<u!HttpResponse>
+    response_code: 200
+    headers: {Mock-Header: OK}
+    data: foo response
+/bar: !<u!HttpResponse>
+    response_code: 500
+    headers: {Mock-Header2: purple}
+    data: bar response
+"""
+
+        expected = {
+            '/foo': http_response.HttpResponse(200, {'Mock-Header': 'OK'},
+                                               'foo response'),
+            '/bar': http_response.HttpResponse(500, {'Mock-Header2': 'purple'},
+                                               'bar response'),
+        }
+        self.assertEqual(expected, http_response.parse_yaml(yaml_contents))
+
+    def test_parse_yaml_raises_exception_when_yaml_is_missing_http_response_field(
+            self):
+        with self.assertRaises(http_response.MissingFieldError):
+            http_response.parse_yaml("""---
+    !<u!HttpResponse>
+        headers: {Mock-Header: OK}
+        data: foo response
+""")
+        with self.assertRaises(http_response.MissingFieldError):
+            http_response.parse_yaml("""---
+    !<u!HttpResponse>
+        response_code: 200
+        data: foo response
+""")
+        with self.assertRaises(http_response.MissingFieldError):
+            http_response.parse_yaml("""---
+    !<u!HttpResponse>
+        response_code: 200
+        headers: {Mock-Header: OK}
+""")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds a class to represent an HTTP response.

We will use this class as part of the native replacement for mitmdump, as it
provides a way of capturing HTTP responses, then saving them in YAML format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/71)
<!-- Reviewable:end -->
