### PR TITLE
Adding an HTTP replay generator

### DIFF
--- a/build
+++ b/build
@@ -10,7 +10,7 @@ coverage run \
 # Check that source has correct formatting.
 yapf --diff --recursive --style google ./ --exclude=./third_party/* &&
 # Run static analysis for Python bugs/cruft.
-pyflakes client_wrapper/*.py tests/*.py &&
+pyflakes client_wrapper/*.py tests/*.py replay_generator/*.py &&
 # Check docstrings for style consistency.
 PYTHONPATH=$PYTHONPATH:$(pwd)/third_party/docstringchecker \
-  pylint --reports=n client_wrapper tests
+  pylint --reports=n client_wrapper replay_generator tests

--- a/replay_generator/README.md
+++ b/replay_generator/README.md
@@ -1,0 +1,100 @@
+# NDT Client HTTP Replay Generator
+
+## Overview
+
+The HTTP replay generator is an HTTP proxy that saves HTTP request and response
+information and processes it so that all requests made during a capture session
+can be reproduced with a single web server replaying the replay file.
+
+Specifically, the replay generator:
+
+* Saves the relative URL (path) of each HTTP request and its corresponding
+  HTTP response information.
+* Replaces all domains found in the traffic with the IP address `127.0.0.1` to
+  facilitate local playback.
+* Decompresses all gzipped HTTP responses
+
+## Replay file
+
+The generator creates an HTTP replay file, which is a simple YAML file
+containing a dictionary or relative URLs mapped to their corresponding HTTP
+response information. All response data is decompressed and saved with UTF-8
+encoding.
+
+## Domain replacement
+
+The replay generator replaces remote domains with the localhost address to
+facilitate local replays. For example, if we capture requests to the following
+URLs
+
+* http://foo.com/abc
+* http://bar.com/def
+
+The replay generator will create a replay file that allows us to replay the
+traffic locally so that the responses are available via a local server like:
+
+* http://127.0.0.1/abc
+* http://127.0.0.1/def
+
+To do this, we need to replace references to `href`s to actual domains with
+`127.0.0.1` in HTTP response data, so the replay generator processes the
+responses to replace these references.
+
+For example a request to http://example.com/welcome with the response:
+
+```html
+<html><body><a href="example.com/bar">Go to Bar!</a></body></html>
+```
+would be saved as:
+
+```html
+<html><body><a href="127.0.0.1/bar">Go to Bar!</a></body></html>
+```
+
+## Limitations
+
+* Replay generator does not preserve any information about relative ordering of
+  requests.
+* Replay generator can only save one response per relative URL.
+  * If the captured traffic includes requests to different URLs with the same
+    relative path (e.g. http://foo.com/abc and http://bar.com/abc) we only save
+    the most recent response for a given relative path.
+* Replay generator only captures traffic for HTTP `GET` requests.
+* Domain replacement is a very naïve string replacement
+  * Domains may be replaced if they're just text and not actual `href`s
+  * We will fail to replace domains if they're constructed dynamically in
+    JavaScript, like
+
+      ```javascript
+      var url = 'performance' + '.example.com';
+      ```
+
+## Example
+To capture traffic for an NDT client at
+http://www.example.com/foo/ndt:
+
+1. Configure Firefox to use a manually set HTTP proxy at address 127.0.0.1 on
+   port 8888.
+1. Set Firefox to skip proxy for the following domains:
+  * `localhost`
+  * `127.0.0.1`
+  * `measurement-lab.org` (we don't want to proxy traffic to an M-Lab NDT
+    server).
+1. Start the replay generator:
+    ```bash
+    python replay_generator/replay_generator.py \
+      --port 8888 \
+      --output example.com-replay.yaml
+    ```
+
+1. Run Firefox in private mode against the target client URL:
+    ```bash
+    firefox -private http://www.example.com/foo/ndt
+    ```
+
+1. Run the NDT client for a single test until the test is complete.
+1. Hit Ctrl+C to stop capturing traffic and save output.
+
+The output file `example.com-replay.yaml` can then be used as the
+`--client_path` parameter to `client_wrapper` to replay the HTTP traffic
+locally.

--- a/replay_generator/replay_generator.py
+++ b/replay_generator/replay_generator.py
@@ -1,0 +1,168 @@
+# Copyright 2016 Measurement Lab
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utility script to capture HTTP traffic.
+
+Runs an HTTP proxy that captures traffic, modifies it for local replay, then
+saves it to an output YAML file. See replay_generator/README.md for additional
+details.
+"""
+import argparse
+import BaseHTTPServer
+import io
+import gzip
+import os
+import SimpleHTTPServer
+import sys
+import urllib2
+import urlparse
+import yaml
+
+sys.path.insert(1, os.path.abspath(os.path.join(
+    os.path.dirname(__file__), '..')))
+
+from client_wrapper import http_response
+
+
+class ResponseSavingHTTPProxy(BaseHTTPServer.HTTPServer):
+    """An HTTP proxy that saves a copy of all HTTP responses in memory.
+
+    An HTTP proxy specifically for HTTP GET requests that saves in memory all
+    responses received from upstream server.
+
+    Attributes:
+        responses: A dictionary where each key is an absolute URL and each value
+            is an HttpResponse instance representing the last response received
+            for a request to that URL.
+    """
+
+    def __init__(self, port):
+        """Creates a new ResponseSavingHTTPProxy.
+
+        Args:
+            port: The local TCP port to listen on for connections.
+        """
+        BaseHTTPServer.HTTPServer.__init__(self, ('', port),
+                                           ResponseSavingRequestHandler)
+        self.responses = {}
+
+
+class ResponseSavingRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+    """An HTTP request handler that saves all responses to its parent server."""
+
+    def do_GET(self):
+        """Process an HTTP GET request."""
+        # Forward the client's request to the actual server.
+        opener = urllib2.build_opener()
+        opener.addheaders = self.headers.items()
+        response = opener.open(self.path)
+
+        headers = {}
+        for header, value in response.info().items():
+            headers[header] = value
+        # Decompress any gzipped HTTP response back to plaintext.
+        if 'content-encoding' in headers and headers[
+                'content-encoding'] == 'gzip':
+            buf = io.BytesIO(response.read())
+            # TODO(mtlynch): Don't assume encoding is ISO-8859-1. Parse it from
+            # the appropriate HTTP header.
+            data = gzip.GzipFile(
+                fileobj=buf).read().decode('iso-8859-1').encode('utf-8')
+            headers.pop('content-encoding', None)
+        else:
+            data = response.read()
+        # Don't use the Transfer-Encoding header because it seems to create
+        # complexities in modifying and replaying traffic. Instead, use the
+        # simpler Content-Length header to indicate the payload size to the
+        # client.
+        if 'transfer-encoding' in headers:
+            headers.pop('transfer-encoding', None)
+        headers['content-length'] = len(data)
+
+        # Send the response to the client.
+        self.send_response(response.getcode())
+        for header, value in headers.iteritems():
+            self.send_header(header, value)
+        self.end_headers()
+        self.wfile.write(data)
+
+        # Save the response.
+        self.server.responses[self.path] = http_response.HttpResponse(
+            response.getcode(), headers, data)
+
+
+def _process_responses(original):
+    """Processes HTTP responses so that they are replayable locally.
+
+    Processes HTTP responses to build a set of all domains that gave HTTP
+    responses, then replaces all references to those domains in the responses
+    with the string 127.0.0.1 so that the responses can be replayed locally.
+
+    Args:
+        original: A dictionary where each key is an absolute URL and each value
+            is an HttpResponse instance.
+
+    Returns:
+        A dictionary where each key is a relative URL and each value is an
+        HttpResponse instance that has been modified to replace hrefs to remote
+        domains with the string 127.0.0.1.
+    """
+    # Build a set of all domains from the URLs that appear in the responses
+    # dictionary.
+    domains = set()
+    for url in original:
+        domains.add(urlparse.urlparse(url).netloc)
+
+    processed = {}
+    for url, response in original.iteritems():
+        # Convert each absolute URL to a relative URL
+        url_parsed = urlparse.urlparse(url)
+        relative_url = url_parsed.path
+        if url_parsed.query:
+            relative_url += '?' + url_parsed.query
+        # Replace all the domains in the response with 127.0.0.1 so that the
+        # responses can be played back locally.
+        data_processed = response.data
+        for domain in domains:
+            data_processed = data_processed.replace(domain, '127.0.0.1')
+
+        if relative_url in processed:
+            print 'warning: multiple responses for relative URL: %s' % relative_url
+        processed[relative_url] = response
+    return processed
+
+
+def main(args):
+    proxy_server = ResponseSavingHTTPProxy(args.port)
+    print 'response capturing proxy listening on port %d, press Ctrl+C to stop' % args.port
+    try:
+        proxy_server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    print 'done collecting HTTP traffic, saving results to %s' % args.output
+    with open(args.output, 'w') as output_file:
+        output_file.write(yaml.dump(_process_responses(proxy_server.responses)))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        prog='HTTP Replay Generator',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--port',
+                        help='Port to listen on',
+                        type=int,
+                        default=8888)
+    parser.add_argument('--output',
+                        help='Directory in which to write output',
+                        required=True)
+    main(parser.parse_args())


### PR DESCRIPTION
This continues the process of replacing the mitmdump dependency. This adds a
script that launches an HTTP proxy that captures traffic and writes it to a
YAML file so that it can be replayed locally.

There are deliberately no unit tests because they'd be fairly complex and this
feels like a utility script more than part of the core application, but we
can add unit tests if necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/72)
<!-- Reviewable:end -->
