### PR TITLE
Fixing replay generator to save processed data

### DIFF
--- a/replay_generator/replay_generator.py
+++ b/replay_generator/replay_generator.py
@@ -138,7 +138,8 @@ def _process_responses(original):
 
         if relative_url in processed:
             print 'warning: multiple responses for relative URL: %s' % relative_url
-        processed[relative_url] = response
+        processed[relative_url] = http_response.HttpResponse(
+            response.response_code, response.headers, data_processed)
     return processed
 
 


### PR DESCRIPTION
Fixing a bug in replay_generator. It's processing the response data, but then
saving the original data instead of the processed data. This fixes the
generator so that it saves the processed data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/75)
<!-- Reviewable:end -->
