### PR TITLE
Reducing UI timeouts from a global 20 seconds to more granular timeouts

### DIFF
--- a/client_wrapper/browser_client_common.py
+++ b/client_wrapper/browser_client_common.py
@@ -22,6 +22,18 @@ from selenium.webdriver.support import ui
 import names
 import results
 
+# Number of seconds to wait for any particular event to occur in the browser UI
+# (e.g. page load, element becomes clickable).
+UI_WAIT_TIMEOUT = 2
+
+# Number of seconds to wait for the test negotiation phase to complete and the
+# test to begin.
+NDT_TEST_NEGOTIATION_TIMEOUT = 8
+
+# Number of seconds to wait for an NDT c2s or s2c test to complete (test is ten
+# seconds, plus four seconds of fudge factor).
+NDT_TEST_RUN_TIMEOUT = 10 + 4
+
 ERROR_FAILED_TO_LOAD_URL_FORMAT = 'Failed to load URL: %s'
 ERROR_TIMED_OUT_WAITING_FOR_PAGE_LOAD = 'Timed out waiting for page to load.'
 

--- a/client_wrapper/client_wrapper.py
+++ b/client_wrapper/client_wrapper.py
@@ -45,8 +45,7 @@ def main(args):
             _run_test_iterations(driver, args.iterations, args.output)
     elif args.client == names.NDT_HTML5:
         driver = html5_driver.NdtHtml5SeleniumDriver(args.browser,
-                                                     args.client_url,
-                                                     timeout=20)
+                                                     args.client_url)
         _run_test_iterations(driver, args.iterations, args.output)
     else:
         raise ValueError('unsupported NDT client: %s' % args.client)

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -67,8 +67,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
             self):
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
+            url='http://ndt.mock-server.com:7123/').perform_test()
 
         self.assertEqual(1.0, result.c2s_result.throughput)
         self.assertEqual(2.0, result.s2c_result.throughput)
@@ -80,8 +79,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
 
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1).perform_test()
+            url='http://ndt.mock-server.com:7123/').perform_test()
 
         self.assertIsNone(result.c2s_result.throughput)
         self.assertIsNone(result.s2c_result.throughput)
@@ -97,8 +95,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
 
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1).perform_test()
+            url='http://ndt.mock-server.com:7123/').perform_test()
 
         self.assertIsNone(result.c2s_result.throughput)
         self.assertIsNone(result.s2c_result.throughput)
@@ -118,8 +115,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
         ]
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1).perform_test()
+            url='http://ndt.mock-server.com:7123/').perform_test()
 
         self.assertErrorMessagesEqual(
             [browser_client_common.ERROR_C2S_NEVER_STARTED,
@@ -136,8 +132,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
         ]
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1).perform_test()
+            url='http://ndt.mock-server.com:7123/').perform_test()
 
         self.assertErrorMessagesEqual(
             [browser_client_common.ERROR_C2S_NEVER_STARTED], result.errors)
@@ -146,8 +141,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
         self.mock_page_elements['latency'] = mock.Mock(text='Non-numeric value')
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
+            url='http://ndt.mock-server.com:7123/').perform_test()
 
         self.assertEqual(1.0, result.c2s_result.throughput)
         self.assertEqual(2.0, result.s2c_result.throughput)
@@ -161,8 +155,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
             text='Non-numeric value')
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
+            url='http://ndt.mock-server.com:7123/').perform_test()
 
         self.assertIsNone(result.c2s_result.throughput)
         self.assertEqual(2.0, result.s2c_result.throughput)
@@ -176,8 +169,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
             text='Non-numeric value')
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
+            url='http://ndt.mock-server.com:7123/').perform_test()
 
         self.assertEqual(1.0, result.c2s_result.throughput)
         self.assertIsNone(result.s2c_result.throughput)
@@ -201,8 +193,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
 
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
+            url='http://ndt.mock-server.com:7123/').perform_test()
 
         self.assertIsNone(result.c2s_result.throughput)
         self.assertIsNone(result.s2c_result.throughput)
@@ -223,8 +214,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
 
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
+            url='http://ndt.mock-server.com:7123/').perform_test()
 
         # Then s2c is converted from Gb/s to Mb/s
         self.assertEqual(72000.0, result.s2c_result.throughput)
@@ -238,8 +228,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
 
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
+            url='http://ndt.mock-server.com:7123/').perform_test()
 
         self.assertIsNone(result.c2s_result.throughput)
         self.assertEqual(2.0, result.s2c_result.throughput)
@@ -256,8 +245,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
         self.mock_page_elements['download-speed-units'] = mock.Mock(text='Mb/s')
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/',
-            timeout=1000).perform_test()
+            url='http://ndt.mock-server.com:7123/').perform_test()
 
         # Then c2s is converted from kb/s to Mb/s
         self.assertEqual(0.072, result.c2s_result.throughput)
@@ -301,8 +289,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
 
             result = html5_driver.NdtHtml5SeleniumDriver(
                 browser='firefox',
-                url='http://ndt.mock-server.com:7123/',
-                timeout=1).perform_test()
+                url='http://ndt.mock-server.com:7123/').perform_test()
 
         # Verify the recorded times matches the expected sequence.
         self.assertEqual(times[0], result.start_time)


### PR DESCRIPTION
Instead of using 20 seconds as the timeout for everything, this uses more
granular timeouts for different aspects of the UI flow. This should improve
performance in the cases where the server is in a bad state and everything
is timing out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/80)
<!-- Reviewable:end -->
