### PR TITLE
Removing client_url parameter

### DIFF
--- a/client_wrapper/client_wrapper.py
+++ b/client_wrapper/client_wrapper.py
@@ -44,8 +44,7 @@ def main(args):
             driver = banjo_driver.BanjoDriver(args.browser, url)
             _run_test_iterations(driver, args.iterations, args.output)
     elif args.client == names.NDT_HTML5:
-        driver = html5_driver.NdtHtml5SeleniumDriver(args.browser,
-                                                     args.client_url)
+        driver = html5_driver.NdtHtml5SeleniumDriver(args.browser, args.server)
         _run_test_iterations(driver, args.iterations, args.output)
     else:
         raise ValueError('unsupported NDT client: %s' % args.client)
@@ -123,8 +122,6 @@ if __name__ == '__main__':
                               'client, these can be replay files, static HTML '
                               'files (not implemented), or a client binary '
                               '(not implemented)'))
-    parser.add_argument('--client_url',
-                        help='URL of NDT client (for server-hosted clients)')
     parser.add_argument('--server', help='FQDN of NDT server to test against')
     parser.add_argument('--output', help='Directory in which to write output')
     parser.add_argument('-v',

--- a/client_wrapper/html5_driver.py
+++ b/client_wrapper/html5_driver.py
@@ -36,15 +36,15 @@ ERROR_TIMED_OUT_WAITING_FOR_START_BUTTON = (
 
 class NdtHtml5SeleniumDriver(object):
 
-    def __init__(self, browser, url):
+    def __init__(self, browser, server_fqdn):
         """Creates a NDT HTML5 client driver for the given URL and browser.
 
         Args:
-            url: The URL of an NDT server to test against.
             browser: Can be one of 'firefox', 'chrome', 'edge', or 'safari'.
+            server_fqdn: The URL of an NDT server to test against.
         """
         self._browser = browser
-        self._url = url
+        self._server_fqdn = server_fqdn
 
     def perform_test(self):
         """Performs a full NDT test (both s2c and c2s) with the HTML5 client.
@@ -62,7 +62,10 @@ class NdtHtml5SeleniumDriver(object):
             result.browser_version = browser_client_common.get_browser_version(
                 driver)
 
-            _complete_ui_flow(driver, self._url, result)
+            # The NDT HTML5 client is hosted on a web server on port 7123 of the
+            # NDT server.
+            url = 'http://%s:7123' % self._server_fqdn
+            _complete_ui_flow(driver, url, result)
 
         result.end_time = datetime.datetime.now(pytz.utc)
         logger.info('NDT HTML5 test ended')

--- a/tests/test_html5_driver.py
+++ b/tests/test_html5_driver.py
@@ -67,7 +67,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
             self):
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/').perform_test()
+            server_fqdn='ndt.mock-server.com').perform_test()
 
         self.assertEqual(1.0, result.c2s_result.throughput)
         self.assertEqual(2.0, result.s2c_result.throughput)
@@ -79,7 +79,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
 
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/').perform_test()
+            server_fqdn='ndt.mock-server.com').perform_test()
 
         self.assertIsNone(result.c2s_result.throughput)
         self.assertIsNone(result.s2c_result.throughput)
@@ -95,7 +95,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
 
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/').perform_test()
+            server_fqdn='ndt.mock-server.com').perform_test()
 
         self.assertIsNone(result.c2s_result.throughput)
         self.assertIsNone(result.s2c_result.throughput)
@@ -115,7 +115,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
         ]
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/').perform_test()
+            server_fqdn='ndt.mock-server.com').perform_test()
 
         self.assertErrorMessagesEqual(
             [browser_client_common.ERROR_C2S_NEVER_STARTED,
@@ -132,7 +132,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
         ]
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/').perform_test()
+            server_fqdn='ndt.mock-server.com').perform_test()
 
         self.assertErrorMessagesEqual(
             [browser_client_common.ERROR_C2S_NEVER_STARTED], result.errors)
@@ -141,7 +141,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
         self.mock_page_elements['latency'] = mock.Mock(text='Non-numeric value')
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/').perform_test()
+            server_fqdn='ndt.mock-server.com').perform_test()
 
         self.assertEqual(1.0, result.c2s_result.throughput)
         self.assertEqual(2.0, result.s2c_result.throughput)
@@ -155,7 +155,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
             text='Non-numeric value')
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/').perform_test()
+            server_fqdn='ndt.mock-server.com').perform_test()
 
         self.assertIsNone(result.c2s_result.throughput)
         self.assertEqual(2.0, result.s2c_result.throughput)
@@ -169,7 +169,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
             text='Non-numeric value')
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/').perform_test()
+            server_fqdn='ndt.mock-server.com').perform_test()
 
         self.assertEqual(1.0, result.c2s_result.throughput)
         self.assertIsNone(result.s2c_result.throughput)
@@ -193,7 +193,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
 
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/').perform_test()
+            server_fqdn='ndt.mock-server.com').perform_test()
 
         self.assertIsNone(result.c2s_result.throughput)
         self.assertIsNone(result.s2c_result.throughput)
@@ -214,7 +214,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
 
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/').perform_test()
+            server_fqdn='ndt.mock-server.com').perform_test()
 
         # Then s2c is converted from Gb/s to Mb/s
         self.assertEqual(72000.0, result.s2c_result.throughput)
@@ -228,7 +228,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
 
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/').perform_test()
+            server_fqdn='ndt.mock-server.com').perform_test()
 
         self.assertIsNone(result.c2s_result.throughput)
         self.assertEqual(2.0, result.s2c_result.throughput)
@@ -245,7 +245,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
         self.mock_page_elements['download-speed-units'] = mock.Mock(text='Mb/s')
         result = html5_driver.NdtHtml5SeleniumDriver(
             browser='firefox',
-            url='http://ndt.mock-server.com:7123/').perform_test()
+            server_fqdn='ndt.mock-server.com').perform_test()
 
         # Then c2s is converted from kb/s to Mb/s
         self.assertEqual(0.072, result.c2s_result.throughput)
@@ -289,7 +289,7 @@ class NdtHtml5SeleniumDriverTest(ndt_client_testcase.NdtClientTestCase):
 
             result = html5_driver.NdtHtml5SeleniumDriver(
                 browser='firefox',
-                url='http://ndt.mock-server.com:7123/').perform_test()
+                server_fqdn='ndt.mock-server.com').perform_test()
 
         # Verify the recorded times matches the expected sequence.
         self.assertEqual(times[0], result.start_time)


### PR DESCRIPTION
This parameter is actually unnecessary. It was originally added for the HTML5
client, which needs a URL rather than a server, but the URL of the HTML5
client can be deduced, given the server FQDN.

Eliminating the client_url parameter simplifies semantics and allows similar
parameters to be used across different client types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/ndt-e2e-clientworker/84)
<!-- Reviewable:end -->
