### PR TITLE
Altered the banjo client path to work with the new replay file. 

### DIFF
--- a/client_wrapper/client_wrapper.py
+++ b/client_wrapper/client_wrapper.py
@@ -39,7 +39,8 @@ def main(args):
             replay_server_manager.start()
             logger.info('replay server replaying %s on port %d',
                         args.client_path, replay_server_manager.port)
-            url = 'http://localhost:%d/banjo' % replay_server_manager.port
+            url = 'http://localhost:%d/search?q=internet+speed+test' % \
+                replay_server_manager.port
             logger.info('starting tests against %s', url)
             driver = banjo_driver.BanjoDriver(args.browser, url)
             _run_test_iterations(driver, args.iterations, args.output)
@@ -123,7 +124,9 @@ if __name__ == '__main__':
                               'files (not implemented), or a client binary '
                               '(not implemented)'))
     parser.add_argument('--server', help='FQDN of NDT server to test against')
-    parser.add_argument('--output', help='Directory in which to write output')
+    parser.add_argument('--output',
+                        help='Directory in which to write output',
+                        required=True)
     parser.add_argument('-v',
                         '--verbose',
                         action='store_true',


### PR DESCRIPTION
Changed the path we run tests against on the local replay server. 

Also in an unrelated change I made output a required argument because when I was testing the new replay file, an error would occur when the output path was not specified.