### PR TITLE
Fix mlab-ns rewriting in http replay server.

### DIFF
--- a/client_wrapper/http_server.py
+++ b/client_wrapper/http_server.py
@@ -91,20 +91,16 @@ class ReplayHTTPServer(BaseHTTPServer.HTTPServer):
             ndt_server_fqdn: Target NDT server to use in rewritten mlab-ns
                 responses.
         """
-        mlabns_response_data = json.dumps({'city': 'Test_TT',
-                                           'url':
-                                           'http://%s:7123' % ndt_server_fqdn,
-                                           'ip': ['1.2.3.4'],
-                                           'fqdn': ndt_server_fqdn,
-                                           'site': 'xyz99',
-                                           'country': 'US'})
-        paths = ['/ndt', '/ndt_ssl']
-        for path in paths:
-            if path in self._replays:
+        for path in self._replays:
+            if path.startswith('/ndt'):
                 original_response = self._replays[path]
+                data = json.loads(original_response.data)
+                for i in range(len(data)):
+                    data[i]['fqdn'] = ndt_server_fqdn
+                rewritten_data = json.dumps(data)
                 self._replays[path] = http_response.HttpResponse(
                     original_response.response_code, original_response.headers,
-                    mlabns_response_data)
+                    rewritten_data)
 
     def _rewrite_localhost_ips(self):
         for path, original_response in self._replays.iteritems():

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -57,8 +57,8 @@ class ReplayHTTPServerTest(unittest.TestCase):
 
     def test_server_rewrites_mlabns_responses(self):
         """Server should rewrite server FQDN in mlab-ns responses."""
-        stored_response = http_response.HttpResponse(200, {},
-                                                     'garbage to rewrite')
+        stored_response = http_response.HttpResponse(
+            200, {}, '[{"fqdn": "garbage to rewrite"}]')
         with contextlib.closing(http_server.create_replay_server_manager({
                 '/ndt_ssl': stored_response
         }, 'mlab1.xyz0t.ndt.mock-lab.org')) as server_manager:
@@ -68,7 +68,7 @@ class ReplayHTTPServerTest(unittest.TestCase):
                                        server_manager.port)
             self.assertEqual(200, response.getcode())
             self.assertEqual('mlab1.xyz0t.ndt.mock-lab.org',
-                             json.loads(response.read())['fqdn'])
+                             json.loads(response.read())[0]['fqdn'])
 
     def test_server_manager_shuts_down_server_on_close(self):
         stored_response = http_response.HttpResponse(200, {}, 'dummy response')


### PR DESCRIPTION
We managed to get a good HTTP replay file from the production Google Search site, but E2E for OneBox was still broken for some reason. Investigating, Fernanda and I discovered that the OneBox client was no longer querying mlab-ns with just `/ndt` or `/ndt_ssl`, but instead with `/ndt_ssl?policy=geo_options`. This caused [the current http_server.py function](https://github.com/fernandalavalle/ndt-e2e-clientworker/blob/public_replay/client_wrapper/http_server.py#L101) for rewriting mlab-ns responses to miss rewriting the response to point to our testing server.

Since we have no control over how the OneBox client queries mlab-ns, this PR assumes that any requests that begins with `/ndt` is an mlab-ns query.

Additional, rather than rewriting the entire mlab-ns request, this PR modifies the rewrite function to just modify the 'fqdn' element(s) of the actual mlab-ns response. This was necessary, because something in the OneBox code expects, and apparently requires, the mlab-ns response to have multiple entries, and will fail if only one exists. Since the 'fqdn' element appears to be all that the OneBox client reads, it seems simpler to just modify the actual mlab-ns response rather than rewriting the entire thing.