### PR TITLE
Substitutes all instances of the domain apis.google.com with 127.0.0.1.

### DIFF
--- a/replay_generator/replay_generator.py
+++ b/replay_generator/replay_generator.py
@@ -120,6 +120,13 @@ def _process_responses(original):
     # Build a set of all domains from the URLs that appear in the responses
     # dictionary.
     domains = set()
+
+    # There are some domains that we want to replace that are not necessarily
+    # URLs that will show up as a key in dict 'original' (likely because the
+    # request was over HTTPS). In such cases, manually add lines below for
+    # additional domains which should be replaced with '127.0.0.1'.
+    domains.add('apis.google.com')
+
     for url in original:
         domains.add(urlparse.urlparse(url).netloc)
 


### PR DESCRIPTION
Most of the data returned from OneBox client requests is javascript, and some of that javascript fetches yet additional resources, and some of that over HTTPS, which our current replay_generator doesn't handle. This PR adds another explicit domain to the list of client request domains that need to be substituted with 127.0.0.1. 

The underlying issue is that testbed clients do not have Internet access, and any request to a host not on the testbed network will fail. The javascript returned by the Google search was attempting to fetch things from https://apis.google.com, which was failing, causing the replay server request from the E2E client to never completely load, causing OneBox tests on Firefox and Safari to fail with timeout errors.

It should be noted that OneBox tests on Chrome always work, and I imagine this has something to do with Chrome using multi-processes and/or other optimizations Chrome makes for loading pages quickly, even while JS resources have yet to fully load.